### PR TITLE
Halborn audit fixes

### DIFF
--- a/shared/services/config/stader-config.go
+++ b/shared/services/config/stader-config.go
@@ -799,7 +799,6 @@ func (cfg *StaderConfig) GenerateEnvironmentVariables() map[string]string {
 	// Basic variables and root parameters
 	envVars["STADER_NODE_IMAGE"] = cfg.StaderNode.GetStadernodeContainerTag()
 	envVars["STADER_FOLDER"] = cfg.StaderDirectory
-	// TODO - we have to pick this from stader config but ethx address shouldnt change
 	envVars["ETHX_ADDRESS"] = cfg.StaderNode.GetEthxTokenAddress().Hex()
 	envVars[FeeRecipientFileEnvVar] = FeeRecipientFilename // If this is running, we're in Docker mode by definition so use the Docker fee recipient filename
 	//envVars["TX_FEE_CAP"] = bigcfg.StaderNode.TxFeeCap.Value.(float64)

--- a/shared/services/gas/gas.go
+++ b/shared/services/gas/gas.go
@@ -220,7 +220,7 @@ func handleEtherchainGasPrices(gasSuggestion etherchain.GasFeeSuggestion, gasInf
 
 		desiredPriceFloat, err := strconv.ParseFloat(desiredPrice, 64)
 		if err != nil {
-			fmt.Println("Not a valid gas price (%s), try again.", err.Error())
+			fmt.Printf("Not a valid gas price (%s), try again.", err.Error())
 			continue
 		}
 		if desiredPriceFloat <= 0 {

--- a/shared/services/wallet/node.go
+++ b/shared/services/wallet/node.go
@@ -170,7 +170,6 @@ func (w *Wallet) getNodeDerivedKey(index uint) (*hdkeychain.ExtendedKey, string,
 	key := w.mk
 	for i, n := range path {
 		// Use the legacy implementation for Goerli
-		// TODO: remove this if Prater ever goes away!
 		if w.chainID.Cmp(big.NewInt(5)) == 0 {
 			key, err = key.DeriveNonStandard(n)
 		} else {

--- a/shared/utils/crypto/rsa.go
+++ b/shared/utils/crypto/rsa.go
@@ -26,31 +26,8 @@ func BytesToPublicKey(pub []byte) (*rsa.PublicKey, error) {
 	return key.(*rsa.PublicKey), nil
 }
 
-func BytesToPrivateKey(pub []byte) (*rsa.PrivateKey, error) {
-	block, _ := pem.Decode(pub)
-	b := block.Bytes
-	var err error
-
-	key, err := x509.ParsePKCS1PrivateKey(b)
-	if err != nil {
-		fmt.Printf("Error using x509.ParsePKIXPublicKey %v\n", err)
-		return nil, err
-	}
-
-	return key, nil
-}
-
 func EncryptUsingPublicKey(data []byte, publicKey *rsa.PublicKey) ([]byte, error) {
 	exitMsgEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, publicKey, data, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return exitMsgEncrypted, nil
-}
-
-func DecryptUsingPublicKey(data []byte, privateKey *rsa.PrivateKey) ([]byte, error) {
-	exitMsgEncrypted, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, privateKey, data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/utils/validator/fee-recipient.go
+++ b/shared/utils/validator/fee-recipient.go
@@ -166,7 +166,6 @@ func StopValidator(cfg *config.StaderConfig, bc beacon.Client, log *log.ColorLog
 			}
 		}
 		if validatorContainerId == "" {
-			// TODO: return here if the container doesn't exist? Is erroring out necessary?
 			return fmt.Errorf("Validator container %s not found", containerName)
 		}
 

--- a/stader-cli/node/withdraw-sd.go
+++ b/stader-cli/node/withdraw-sd.go
@@ -36,7 +36,6 @@ func WithdrawSd(c *cli.Context) error {
 		return err
 	}
 	if canWithdrawSdResponse.InsufficientWithdrawableSd {
-		// TODO - bchain - rework error messages
 		fmt.Println("Insufficient withdrawable SD!")
 		return nil
 	}

--- a/stader-cli/service/configConsensus.go
+++ b/stader-cli/service/configConsensus.go
@@ -176,7 +176,6 @@ func updateLocalConsensusClient(newCfg *stdCf.StaderConfig, settings map[string]
 	newCfg.Teku.AdditionalBnFlags.Value = settings[keys.E2cc_lc_additional_beacon_node_flags_teku]
 	newCfg.Teku.AdditionalVcFlags.Value = settings[keys.E2cc_lc_additional_client_flags_teku]
 
-	// Nimbus TODO? check
 	newCfg.Nimbus.BnContainerTag.Value = settings[keys.E2cc_lc_container_tag_nimbus]
 	newCfg.Nimbus.AdditionalBnFlags.Value = settings[keys.E2cc_lc_additional_flags_nimbus]
 

--- a/stader-cli/service/configMonitoring.go
+++ b/stader-cli/service/configMonitoring.go
@@ -33,7 +33,6 @@ func setUIMonitoring(cfg *stdCf.StaderConfig, newSettings map[string]interface{}
 	newSettings[keys.Nm_exporter_metrics_port] = format(cfg.ExporterMetricsPort.Value)
 	newSettings[keys.Nm_guardian_oracle_port] = "9104"
 
-	// TODO:
 	// Nm_guardian_oracle_port ??
 	// Nm_allow_root_filesystem_access ??
 	// Nm_enable_oracle_dao_metrics?
@@ -75,7 +74,6 @@ func updateMonitoring(cfg *stdCf.StaderConfig, newSettings map[string]interface{
 
 	// cfg.GuardianMetricsPort.Value =
 
-	// TODO:
 	// Nm_guardian_oracle_port ??
 	// Nm_allow_root_filesystem_access ??
 	// Nm_enable_oracle_dao_metrics?

--- a/stader-cli/service/service.go
+++ b/stader-cli/service/service.go
@@ -775,7 +775,6 @@ func checkForValidatorChange(stader *stader.Client, cfg *config.StaderConfig) er
 }
 
 // Get the name of the container responsible for validator duties based on the client name
-// TODO: this is temporary and can change, clean it up when Nimbus supports split mode
 func getContainerNameForValidatorDuties(CurrentValidatorClientName string, sd *stader.Client) (string, error) {
 
 	prefix, err := getContainerPrefix(sd)


### PR DESCRIPTION
1. Remove code to convert bytes to private key and to decrypt a message using private key. It is not being used
2. Remove TODOs
3. Use Printf instead of Println in one instance