### PR TITLE
Minor updates

### DIFF
--- a/shared/services/config/mev-boost-config.go
+++ b/shared/services/config/mev-boost-config.go
@@ -29,7 +29,7 @@ import (
 
 // Constants
 const (
-	mevBoostPortableTag         string = "flashbots/mev-boost:1.6-portable"
+	mevBoostPortableTag         string = "flashbots/mev-boost:1.6"
 	mevBoostModernTag           string = "flashbots/mev-boost:1.6"
 	mevBoostUrlEnvVar           string = "MEV_BOOST_URL"
 	mevBoostRelaysEnvVar        string = "MEV_BOOST_RELAYS"

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -64,7 +64,9 @@ type MetricDetails struct {
 	// done
 	ActiveValidators *big.Int
 	// done
-	QueuedValidators *big.Int
+	StaderQueuedValidators *big.Int
+	// done
+	BeaconChainQueuedValidators *big.Int
 	// done
 	SlashedValidators *big.Int
 	// done
@@ -283,7 +285,8 @@ func CreateMetricsCache(
 
 	activeValidators := big.NewInt(0)
 	slashedValidators := big.NewInt(0)
-	queuedValidators := big.NewInt(0)
+	staderQueuedValidators := big.NewInt(0)
+	beaconChainQueuedValidators := big.NewInt(0)
 	exitingValidators := big.NewInt(0)
 	withdrawnValidators := big.NewInt(0)
 	initializedValidators := big.NewInt(0)
@@ -332,11 +335,11 @@ func CreateMetricsCache(
 			continue
 		}
 		if !inBeaconChain && validatorContractInfo.Status == 3 {
-			queuedValidators.Add(queuedValidators, big.NewInt(1))
+			staderQueuedValidators.Add(staderQueuedValidators, big.NewInt(1))
 			continue
 		}
 		if !inBeaconChain && validatorContractInfo.Status == 4 {
-			queuedValidators.Add(queuedValidators, big.NewInt(1))
+			staderQueuedValidators.Add(staderQueuedValidators, big.NewInt(1))
 			continue
 		}
 		if validatorContractInfo.Status == 5 {
@@ -352,7 +355,7 @@ func CreateMetricsCache(
 			continue
 		}
 		if inBeaconChain && eth2.IsValidatorQueued(status) {
-			queuedValidators.Add(queuedValidators, big.NewInt(1))
+			beaconChainQueuedValidators.Add(beaconChainQueuedValidators, big.NewInt(1))
 		}
 		if inBeaconChain && eth2.IsValidatorSlashed(status) {
 			slashedValidators.Add(slashedValidators, big.NewInt(1))
@@ -468,7 +471,8 @@ func CreateMetricsCache(
 	metricsDetails.ValidatorStatusMap = statusMap
 	metricsDetails.ValidatorInfoMap = validatorInfoMap
 	metricsDetails.ActiveValidators = activeValidators
-	metricsDetails.QueuedValidators = queuedValidators
+	metricsDetails.BeaconChainQueuedValidators = beaconChainQueuedValidators
+	metricsDetails.StaderQueuedValidators = staderQueuedValidators
 	metricsDetails.ExitingValidators = exitingValidators
 	metricsDetails.SlashedValidators = slashedValidators
 	metricsDetails.WithdrawnValidators = withdrawnValidators

--- a/shared/utils/wallet/recover-keys.go
+++ b/shared/utils/wallet/recover-keys.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stader-labs/stader-node/stader-lib/node"
 	"github.com/stader-labs/stader-node/stader-lib/stader"
 	"github.com/stader-labs/stader-node/stader-lib/types"
+	"math/big"
 )
 
 const (
@@ -16,9 +17,13 @@ const (
 )
 
 func RecoverStaderKeys(pnr *stader.PermissionlessNodeRegistryContractManager, address common.Address, w *wallet.Wallet, testOnly bool) ([]types.ValidatorPubkey, error) {
+	recoveredKeys := []types.ValidatorPubkey{}
 	operatorId, err := node.GetOperatorId(pnr, address, nil)
 	if err != nil {
 		return nil, err
+	}
+	if operatorId.Cmp(big.NewInt(0)) == 0 {
+		return recoveredKeys, nil
 	}
 	// Get node's validating pubkeys
 	allOperatorValidators, _, err := stdr.GetAllValidatorsRegisteredWithOperator(pnr, operatorId, address, nil)
@@ -26,7 +31,6 @@ func RecoverStaderKeys(pnr *stader.PermissionlessNodeRegistryContractManager, ad
 		return nil, err
 	}
 
-	recoveredKeys := []types.ValidatorPubkey{}
 	// Recover conventionally generated keys
 	pageStart := uint(0)
 	for {

--- a/stader-cli/wallet/recover.go
+++ b/stader-cli/wallet/recover.go
@@ -51,7 +51,7 @@ func recoverWallet(c *cli.Context) error {
 	}
 
 	// Prompt a notice about test recovery
-	fmt.Printf("%sNOTE:\nThis command will fully regenerate your node wallet's private key and (unless explicitly disabled) the validator keys for your validators.\nIf you just want to test recovery to ensure it works without actually regenerating the files, please use `stader-cli wallet test-recovery` instead.%s\n\n", log.ColorYellow, log.ColorReset)
+	fmt.Printf("%sNOTE:\nThis command will fully regenerate your node wallet's private key and (unless explicitly disabled) the validator keys for your validators.%s\n\n", log.ColorYellow, log.ColorReset)
 
 	// Set password if not set
 	if !status.PasswordSet {
@@ -108,6 +108,7 @@ func recoverWallet(c *cli.Context) error {
 		fmt.Printf("Derivation path: %s\n", response.DerivationPath)
 		fmt.Printf("Wallet index:    %d\n", response.Index)
 		fmt.Printf("Node account:    %s\n", response.AccountAddress.Hex())
+
 		if !skipValidatorKeyRecovery {
 			if len(response.ValidatorKeys) > 0 {
 				fmt.Println("Validator keys:")

--- a/stader/guardian/collector/constants.go
+++ b/stader/guardian/collector/constants.go
@@ -5,8 +5,9 @@ const namespace = "stader"
 // Validator rewards & performance => stader_validator_rewards_performance + key
 const OperatorSub = "operator"
 
-const ActiveValidators = "active_validators"                      //GetAllActiveValidators _PermissionlessNodeRegistry
-const QueuedValidators = "queued_validators"                      //QueuedValidators _PermissionlessNodeRegistry
+const ActiveValidators = "active_validators"                         //GetAllActiveValidators _PermissionlessNodeRegistry
+const BeaconChainQueuedValidators = "beacon_chain_queued_validators" //BeaconChainQueuedValidators _PermissionlessNodeRegistry
+const StaderQueuedValidators = "stader_queued_validators"
 const SlashedValidators = "slashed_validators"                    //GetValidatorStatus
 const ExitingValidators = "exiting_validators"                    //GetValidatorStatus
 const WithdrawnValidators = "withdrawn_validators"                //GetValidatorStatus

--- a/stader/guardian/collector/operator-collector.go
+++ b/stader/guardian/collector/operator-collector.go
@@ -14,7 +14,8 @@ import (
 // Represents the collector for the stader network metrics
 type OperatorCollector struct {
 	ActiveValidators                     *prometheus.Desc
-	QueuedValidators                     *prometheus.Desc
+	BeaconChainQueuedValidators          *prometheus.Desc
+	StaderQueuedValidators               *prometheus.Desc
 	SlashedValidators                    *prometheus.Desc
 	ExitingValidators                    *prometheus.Desc
 	WithdrawnValidators                  *prometheus.Desc
@@ -60,8 +61,11 @@ func NewOperatorCollector(
 		ActiveValidators: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, OperatorSub, ActiveValidators), "", nil, nil,
 		),
-		QueuedValidators: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, OperatorSub, QueuedValidators), "", nil, nil,
+		BeaconChainQueuedValidators: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, OperatorSub, BeaconChainQueuedValidators), "", nil, nil,
+		),
+		StaderQueuedValidators: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, OperatorSub, StaderQueuedValidators), "", nil, nil,
 		),
 		SlashedValidators: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, OperatorSub, SlashedValidators), "", nil, nil,
@@ -119,7 +123,8 @@ func NewOperatorCollector(
 // Write metric descriptions to the Prometheus channel
 func (collector *OperatorCollector) Describe(channel chan<- *prometheus.Desc) {
 	channel <- collector.ActiveValidators
-	channel <- collector.QueuedValidators
+	channel <- collector.BeaconChainQueuedValidators
+	channel <- collector.StaderQueuedValidators
 	channel <- collector.SlashedValidators
 	channel <- collector.ExitingValidators
 	channel <- collector.FrontRunValidators
@@ -145,7 +150,8 @@ func (collector *OperatorCollector) Collect(channel chan<- prometheus.Metric) {
 	state := collector.stateLocker.GetMetricsContainer()
 
 	channel <- prometheus.MustNewConstMetric(collector.ActiveValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.ActiveValidators.Int64()))
-	channel <- prometheus.MustNewConstMetric(collector.QueuedValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.QueuedValidators.Int64()))
+	channel <- prometheus.MustNewConstMetric(collector.BeaconChainQueuedValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.BeaconChainQueuedValidators.Int64()))
+	channel <- prometheus.MustNewConstMetric(collector.StaderQueuedValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.StaderQueuedValidators.Int64()))
 	channel <- prometheus.MustNewConstMetric(collector.SlashedValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.SlashedValidators.Int64()))
 	channel <- prometheus.MustNewConstMetric(collector.ExitingValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.ExitingValidators.Int64()))
 	channel <- prometheus.MustNewConstMetric(collector.WithdrawnValidators, prometheus.GaugeValue, float64(state.StaderNetworkDetails.WithdrawnValidators.Int64()))

--- a/stader/guardian/collector/state-locker.go
+++ b/stader/guardian/collector/state-locker.go
@@ -29,7 +29,7 @@ func NewMetricsCacheContainer() *MetricsCacheContainer {
 				TotalEthxSupply:                      0,
 				TotalStakedEthByUsers:                big.NewInt(0),
 				ActiveValidators:                     big.NewInt(0),
-				QueuedValidators:                     big.NewInt(0),
+				BeaconChainQueuedValidators:          big.NewInt(0),
 				SlashedValidators:                    big.NewInt(0),
 				ExitingValidators:                    big.NewInt(0),
 				WithdrawnValidators:                  big.NewInt(0),


### PR DESCRIPTION
1. Avoid using mev portable builds
2. Seperate out metrics for stader queued validators(validators queued for 28Eth) and beacon chain queued validators(validators in Activation queue)
3. don't fail wallet recovery if an operator is trying to recover a mnemonic which has not been registered with stader 