### PR TITLE
Use inital block as start block for cycle 1 rewards of socializing pool

### DIFF
--- a/shared/services/config/stadernode-config.go
+++ b/shared/services/config/stadernode-config.go
@@ -523,7 +523,6 @@ func (cfg *StaderNodeConfig) GetClaimData(cycles []*big.Int) ([]*big.Int, []*big
 }
 
 func (cfg *StaderNodeConfig) ReadCycleCache(cycle int64) (stader_backend.CycleMerkleProofs, bool, error) {
-	//fmt.Printf("Reading cycle cache for cycle %d\n", cycle)
 	cycleMerkleProofFile := cfg.GetSpRewardCyclePath(cycle, true)
 	absolutePathOfProofFile, err := homedir.Expand(cycleMerkleProofFile)
 	if err != nil {

--- a/stader-cli/node/claim-sp-rewards.go
+++ b/stader-cli/node/claim-sp-rewards.go
@@ -86,7 +86,7 @@ func ClaimSpRewards(c *cli.Context) error {
 				continue
 			}
 
-			fmt.Printf("%-18d%-14.30s%-14.14f%-.14f\n", cycleInfo.MerkleProofInfo.Cycle, cycleInfo.CycleTime.Format("2006-01-02"), ethRewardsConverted, sdRewardsConverted)
+			fmt.Printf("%-18d%-14.30s%-14.4f%-.4f\n", cycleInfo.MerkleProofInfo.Cycle, cycleInfo.CycleTime.Format("2006-01-02"), ethRewardsConverted, sdRewardsConverted)
 		}
 
 		cycleSelection := cliutils.Prompt("Select the cycles for which you wish to claim the rewards. Enter the cycles numbers in a comma separate format without any space (e.g. 1,2,3,4) or leave it blank to claim all cycles at once.", "^$|^\\d+(,\\d+)*$", "Unexpected input. Please enter a comma separated list of cycle numbers or leave it blank to claim all cycles at once.")

--- a/stader-cli/node/status.go
+++ b/stader-cli/node/status.go
@@ -132,11 +132,11 @@ func getNodeStatus(c *cli.Context) error {
 	}
 
 	if totalUnclaimedSocializingPoolSd.Cmp(big.NewInt(0)) > 0 {
-		fmt.Printf("The Operator has %.14f SD as unclaimed SD rewards. To claim SD rewards using the %sstader-cli node claim-sp-rewards%s command\n\n", math.RoundDown(eth.WeiToEth(totalUnclaimedSocializingPoolSd), 18), log.ColorGreen, log.ColorReset)
+		fmt.Printf("The Operator has %.6f SD as unclaimed SD rewards. To claim SD rewards using the %sstader-cli node claim-sp-rewards%s command\n\n", math.RoundDown(eth.WeiToEth(totalUnclaimedSocializingPoolSd), 18), log.ColorGreen, log.ColorReset)
 	}
 
 	if totalUnclaimedSocializingPoolEth.Cmp(big.NewInt(0)) > 0 {
-		fmt.Printf("The Operator has %.14f ETH as unclaimed Socializing Pool EL rewards. To claim Socialized EL rewards using the %sstader-cli node claim-sp-rewards%s command\n\n", math.RoundDown(eth.WeiToEth(totalUnclaimedSocializingPoolEth), 18), log.ColorGreen, log.ColorReset)
+		fmt.Printf("The Operator has %.6f ETH as unclaimed Socializing Pool EL rewards. To claim Socialized EL rewards using the %sstader-cli node claim-sp-rewards%s command\n\n", math.RoundDown(eth.WeiToEth(totalUnclaimedSocializingPoolEth), 18), log.ColorGreen, log.ColorReset)
 	}
 
 	if status.OperatorELRewardsAddressBalance.Cmp(big.NewInt(0)) > 0 {

--- a/stader-lib/socializing-pool/rewards.go
+++ b/stader-lib/socializing-pool/rewards.go
@@ -30,6 +30,10 @@ func GetRewardCycleDetails(sp *stader.SocializingPoolContractManager, cycle *big
 	return sp.SocializingPool.GetRewardCycleDetails(opts, cycle)
 }
 
+func GetSocializingPoolInitialBlock(sp *stader.SocializingPoolContractManager, opts *bind.CallOpts) (*big.Int, error) {
+	return sp.SocializingPool.InitialBlock(opts)
+}
+
 func HasClaimedRewards(sp *stader.SocializingPoolContractManager, address common.Address, index *big.Int, opts *bind.CallOpts) (bool, error) {
 	return sp.SocializingPool.ClaimedRewards(opts, address, index)
 }

--- a/stader/api/node/claim-sp-rewards.go
+++ b/stader/api/node/claim-sp-rewards.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"fmt"
 	"github.com/stader-labs/stader-node/shared/services"
 	"github.com/stader-labs/stader-node/shared/types/api"
 	"github.com/stader-labs/stader-node/shared/utils/eth1"
@@ -25,12 +24,10 @@ func GetCyclesDetailedInfo(c *cli.Context, stringifiedCycles string) (*api.Cycle
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("cycles is %v\n", cycles)
 
 	response := api.CyclesDetailedInfo{}
 	merkleProofs := []api.DetailedMerkleProofInfo{}
 	for _, cycle := range cycles {
-		fmt.Printf("cycle is %v\n", cycle)
 		merkleCycleProof, exists, err := cfg.StaderNode.ReadCycleCache(cycle.Int64())
 		if err != nil {
 			return nil, err
@@ -49,8 +46,18 @@ func GetCyclesDetailedInfo(c *cli.Context, stringifiedCycles string) (*api.Cycle
 		}
 
 		cycleStartBlock := currentBlock
-		if cycleDetails.StartBlock.Cmp(big.NewInt(int64(currentBlock))) < 0 {
-			cycleStartBlock = cycleDetails.StartBlock.Uint64()
+		// this is a special case for cycle 1, since in socializing pool contract cycle 1 has startBlock as 1
+		// which will not be available in the block history of primary eth1 clients
+		if merkleCycleProof.Cycle == 1 {
+			initialSocializingPoolBlock, err := socializing_pool.GetSocializingPoolInitialBlock(sp, nil)
+			if err != nil {
+				return nil, err
+			}
+			cycleStartBlock = initialSocializingPoolBlock.Uint64()
+		} else {
+			if cycleDetails.StartBlock.Cmp(big.NewInt(int64(currentBlock))) < 0 {
+				cycleStartBlock = cycleDetails.StartBlock.Uint64()
+			}
 		}
 		cycleStartTime, err := eth1.ConvertBlockToTimestamp(c, int64(cycleStartBlock))
 		if err != nil {

--- a/stader/api/node/claim-sp-rewards.go
+++ b/stader/api/node/claim-sp-rewards.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"fmt"
 	"github.com/stader-labs/stader-node/shared/services"
 	"github.com/stader-labs/stader-node/shared/types/api"
 	"github.com/stader-labs/stader-node/shared/utils/eth1"
@@ -24,10 +25,12 @@ func GetCyclesDetailedInfo(c *cli.Context, stringifiedCycles string) (*api.Cycle
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("cycles is %v\n", cycles)
 
 	response := api.CyclesDetailedInfo{}
 	merkleProofs := []api.DetailedMerkleProofInfo{}
 	for _, cycle := range cycles {
+		fmt.Printf("cycle is %v\n", cycle)
 		merkleCycleProof, exists, err := cfg.StaderNode.ReadCycleCache(cycle.Int64())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In the socializing pool contract, the startBlock for cycle 1 is block 1. Primary execution clients won't have block 1 in their block history since they are not archive nodes. Furthur socializing pool blocks will be available in the primary execution client block history. So for cycle 1, we can just use the initial block of the socializing pool contract