### PR TITLE
Check for nil

### DIFF
--- a/shared/utils/stader/pre-signed-flows.go
+++ b/shared/utils/stader/pre-signed-flows.go
@@ -3,6 +3,7 @@ package stader
 import (
 	"crypto/rsa"
 	"encoding/json"
+
 	"github.com/stader-labs/stader-node/shared/services"
 	stader_backend "github.com/stader-labs/stader-node/shared/types/stader-backend"
 	"github.com/stader-labs/stader-node/shared/utils/crypto"
@@ -82,6 +83,10 @@ func BulkIsPresignedKeyRegistered(c *cli.Context, validatorPubKeys []types.Valid
 	}
 
 	res, err := net.MakePostRequest(config.StaderNode.GetBulkPresignCheckApi(), stader_backend.BulkPreSignCheckApiRequestType{ValidatorPubKeys: validatorPubKeys})
+
+	if res == nil || err != nil {
+		return nil, err
+	}
 
 	defer res.Body.Close()
 


### PR DESCRIPTION
To fix my issue


stader_node  | goroutine 57 [running]:
stader_node  | github.com/stader-labs/stader-node/shared/utils/stader.BulkIsPresignedKeyRegistered(0xc0004000a0?, {0xc000396000, 0x3, 0x4})
stader_node  | 	/stader-node/shared/utils/stader/pre-signed-flows.go:86 +0x134
stader_node  | github.com/stader-labs/stader-node/stader/node.run.func1()
stader_node  | 	/stader-node/stader/node/node.go:185 +0x5ca
stader_node  | created by github.com/stader-labs/stader-node/stader/node.run
stader_node  | 	/stader-node/stader/node/node.go:139 +0x44c
stader_node  | 2023/08/31 17:58:13 Checking if there are any available merkle proofs to download
stader_node  | 2023/08/31 17:58:13 Building a map of user validators registered with stader
stader_node  | 2023/08/31 17:58:13 Found 3 validators registered with operator 49
stader_node  | 2023/08/31 17:58:13 Starting a pass of the presign daemon!
stader_node  | 2023/08/31 17:58:13 Fee recipient files are all correct, no action required.
stader_node  | panic: runtime error: invalid memory address or nil pointer dereference
stader_node  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x9e4d34]
stader_node  | 
stader_node  | 
stader_node  | goroutine 16 [running]:
stader_node  | github.com/stader-labs/stader-node/shared/utils/stader.BulkIsPresignedKeyRegistered(0xc0000c4460?, {0xc00039c000, 0x3, 0x4})
stader_node  | 	/stader-node/shared/utils/stader/pre-signed-flows.go:86 +0x134
stader_node  | github.com/stader-labs/stader-node/stader/node.run.func1()
stader_node  | 	/stader-node/stader/node/node.go:185 +0x5ca
stader_node  | created by github.com/stader-labs/stader-node/stader/node.run
stader_node  | 	/stader-node/stader/node/node.go:139 +0x44c
stader_node  | 2023/08/31 17:58:47 Checking if there are any available merkle proofs to download
stader_node  | 2023/08/31 17:58:47 Building a map of user validators registered with stader
stader_node  | 2023/08/31 17:58:47 Found 3 validators registered with operator 49
stader_node  | 2023/08/31 17:58:47 Starting a pass of the presign daemon!
stader_node  | 2023/08/31 17:58:47 Fee recipient files are all correct, no action required.
stader_node  | panic: runtime error: invalid memory address or nil pointer dereference
stader_node  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x9e4d34]
stader_node  | 