### PR TITLE
v1.4.3

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -56,6 +56,7 @@ build_install_packages() {
     tar cfJ stader-node-install.tar.xz install || fail "Error building installer package."
     mv stader-node-install.tar.xz build/$VERSION
     cp install.sh build/$VERSION
+    cp update_package.sh build/$VERSION
     aws s3 cp build/$VERSION s3://$S3_BUCKET/$VERSION --recursive
     echo "done!"
 

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf // indirect
 	github.com/sethvargo/go-password v0.2.0
 	github.com/shirou/gopsutil/v3 v3.23.1
-	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231016124941-f6dc59b3b0ff
-	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231016124941-f6dc59b3b0ff
+	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff
+	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli v1.22.10
 	github.com/wealdtech/go-eth2-types/v2 v2.7.0

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf // indirect
 	github.com/sethvargo/go-password v0.2.0
 	github.com/shirou/gopsutil/v3 v3.23.1
-	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff
-	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff
+	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231101111158-6c1993b3d9ae
+	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231101111158-6c1993b3d9ae
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli v1.22.10
 	github.com/wealdtech/go-eth2-types/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -1231,10 +1231,10 @@ github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7Sr
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231016124941-f6dc59b3b0ff h1:BIoOmo3mDvZer2FUF63LU1w08k5jOBcpBF6Ac/IIX+Q=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231016124941-f6dc59b3b0ff/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231016124941-f6dc59b3b0ff h1:/snabGli4t4fC41ofKSFwBOD39rK99m+DkmxD9m0i+k=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231016124941-f6dc59b3b0ff/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff h1:Am6vnY/1VdZtawnQA0aY4K1/fc3e7c+gk0EGCfAusVw=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff h1:nxpM4fjXdMxEsUUOIDWnd/ZduoeXJxDiOGJOh/+bwW8=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/go.sum
+++ b/go.sum
@@ -1231,10 +1231,10 @@ github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7Sr
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff h1:Am6vnY/1VdZtawnQA0aY4K1/fc3e7c+gk0EGCfAusVw=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231031151944-2d6ecf9617ff/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff h1:nxpM4fjXdMxEsUUOIDWnd/ZduoeXJxDiOGJOh/+bwW8=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231031151944-2d6ecf9617ff/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231101111158-6c1993b3d9ae h1:ryMYcnorBrjYme+1y+f0b7Jdh3rLpkprC+60mfN8tZM=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231101111158-6c1993b3d9ae/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231101111158-6c1993b3d9ae h1:4NMIuQQyqLisG7cJoYU8E8tRq6mz1yKvCOdGc0h2EF4=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231101111158-6c1993b3d9ae/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/install/scripts/start-ec.sh
+++ b/install/scripts/start-ec.sh
@@ -90,6 +90,11 @@ if [ "$CLIENT" = "geth" ]; then
         DB_ENGINE="--db.engine=pebble"
     fi
 
+    # Use new state stoore scheme if requested
+    if [ "$STADER_GETH_ENABLE_PBSS" = "true" ]; then
+    CMD="$CMD --state.scheme=path"
+    fi
+
     # Init the zhejiang data if necessary
     if [ "$NETWORK" = "zhejiang" ]; then
         if [ ! -f "/ethclient/zhejiang.init" ]; then

--- a/install/templates/eth1.tmpl
+++ b/install/templates/eth1.tmpl
@@ -65,6 +65,7 @@ services:
       - TX_FEE_CAP=${TX_FEE_CAP}
       - TX_FEE_CAP_IN_WEI=${TX_FEE_CAP_IN_WEI}
       - TX_FEE_CAP_IN_GWEI=${TX_FEE_CAP_IN_GWEI}
+      - STADER_GETH_ENABLE_PBSS=${GETH_ENABLE_PBSS}
     entrypoint: sh
     command: "/setup/start-ec.sh"
     cap_drop:

--- a/shared/services/config/besu-params.go
+++ b/shared/services/config/besu-params.go
@@ -25,8 +25,8 @@ import (
 
 // Constants
 const (
-	besuTagTest          string = "hyperledger/besu:23.7.1"
-	besuTagProd          string = "hyperledger/besu:23.7.1"
+	besuTagTest          string = "hyperledger/besu:23.10.0"
+	besuTagProd          string = "hyperledger/besu:23.10.0"
 	besuEventLogInterval int    = 1000
 	besuMaxPeers         uint16 = 25
 	besuStopSignal       string = "SIGTERM"

--- a/shared/services/config/geth-params.go
+++ b/shared/services/config/geth-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	gethTagProd          string = "ethereum/client-go:v1.12.2"
-	gethTagTest          string = "ethereum/client-go:v1.12.2"
+	gethTagProd          string = "ethereum/client-go:v1.13.2"
+	gethTagTest          string = "ethereum/client-go:v1.13.2"
 	gethEventLogInterval int    = 1000
 	gethStopSignal       string = "SIGTERM"
 )
@@ -58,6 +58,9 @@ type GethConfig struct {
 
 	// The Docker Hub tag for Geth
 	ContainerTag config.Parameter `yaml:"containerTag,omitempty"`
+
+	// The flag for enabling PBSS
+	EnablePbss config.Parameter `yaml:"enablePbss,omitempty"`
 
 	// Custom command line flags
 	AdditionalFlags config.Parameter `yaml:"additionalFlags,omitempty"`
@@ -131,6 +134,18 @@ func NewGethConfig(cfg *StaderConfig) *GethConfig {
 			OverwriteOnUpgrade:   true,
 		},
 
+		EnablePbss: config.Parameter{
+			ID:                   "enablePbss",
+			Name:                 "Enable PBSS",
+			Description:          "Enable Geth's new path-based state scheme. With this enabled, you will no longer need to manually prune Geth; it will automatically prune its database in real-time.\n\n[orange]NOTE:\nEnabling this will require you to remove and resync your Geth DB using `stader-cli service resync-eth1`.\nYou will need a synced fallback node configured before doing this, or you will no longer be able to attest until it has finished resyncing!",
+			Type:                 config.ParameterType_Bool,
+			Default:              map[config.Network]interface{}{config.Network_All: false},
+			AffectsContainers:    []config.ContainerID{config.ContainerID_Eth1},
+			EnvironmentVariables: []string{"GETH_ENABLE_PBSS"},
+			CanBeBlank:           false,
+			OverwriteOnUpgrade:   false,
+		},
+
 		AdditionalFlags: config.Parameter{
 			ID:                   "additionalFlags",
 			Name:                 "Additional Flags",
@@ -181,6 +196,7 @@ func (cfg *GethConfig) GetParameters() []*config.Parameter {
 		&cfg.MaxPeers,
 		&cfg.UsePebble,
 		&cfg.ContainerTag,
+		&cfg.EnablePbss,
 		&cfg.AdditionalFlags,
 	}
 }

--- a/shared/services/config/lighthouse-config.go
+++ b/shared/services/config/lighthouse-config.go
@@ -25,10 +25,10 @@ import (
 )
 
 const (
-	lighthouseTagPortableTest string = "sigp/lighthouse:v4.3.0"
-	lighthouseTagPortableProd string = "sigp/lighthouse:v4.3.0"
-	lighthouseTagModernTest   string = "sigp/lighthouse:v4.3.0-modern"
-	lighthouseTagModernProd   string = "sigp/lighthouse:v4.3.0-modern"
+	lighthouseTagPortableTest string = "sigp/lighthouse:v4.5.0"
+	lighthouseTagPortableProd string = "sigp/lighthouse:v4.5.0"
+	lighthouseTagModernTest   string = "sigp/lighthouse:v4.5.0-modern"
+	lighthouseTagModernProd   string = "sigp/lighthouse:v4.5.0-modern"
 	defaultLhMaxPeers         uint16 = 80
 )
 

--- a/shared/services/config/lodestar-config.go
+++ b/shared/services/config/lodestar-config.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	lodestarTagTest         string = "chainsafe/lodestar:v1.10.0"
-	lodestarTagProd         string = "chainsafe/lodestar:v1.10.0"
+	lodestarTagTest         string = "chainsafe/lodestar:v1.11.3"
+	lodestarTagProd         string = "chainsafe/lodestar:v1.11.3"
 	defaultLodestarMaxPeers uint16 = 50
 )
 

--- a/shared/services/config/mev-boost-config.go
+++ b/shared/services/config/mev-boost-config.go
@@ -80,6 +80,9 @@ type MevBoostConfig struct {
 	// Aestus relay
 	AestusRelay config.Parameter `yaml:"aestusEnabled,omitempty"`
 
+	// Agnostic relay
+	AgnosticRelay config.Parameter `yaml:"AgnoticEnabled,omitempty"`
+
 	// The RPC port
 	Port config.Parameter `yaml:"port,omitempty"`
 
@@ -172,6 +175,7 @@ func NewMevBoostConfig(cfg *StaderConfig) *MevBoostConfig {
 		EdenRelay:               generateRelayParameter("edenEnabled", relayMap[config.MevRelayID_Eden]),
 		UltrasoundRelay:         generateRelayParameter("ultrasoundEnabled", relayMap[config.MevRelayID_Ultrasound]),
 		AestusRelay:             generateRelayParameter("aestusEnabled", relayMap[config.MevRelayID_Aestus]),
+		AgnosticRelay:           generateRelayParameter("agnosticEnabled", relayMap[config.MevRelayID_Agnostic]),
 
 		Port: config.Parameter{
 			ID:                   "port",
@@ -253,6 +257,7 @@ func (cfg *MevBoostConfig) GetParameters() []*config.Parameter {
 		&cfg.EdenRelay,
 		&cfg.UltrasoundRelay,
 		&cfg.AestusRelay,
+		&cfg.AgnosticRelay,
 		&cfg.Port,
 		&cfg.OpenRpcPort,
 		&cfg.ContainerTag,
@@ -378,6 +383,13 @@ func (cfg *MevBoostConfig) GetEnabledMevRelays() []config.MevRelay {
 				relays = append(relays, cfg.relayMap[config.MevRelayID_Aestus])
 			}
 		}
+
+		if cfg.AgnosticRelay.Value == true {
+			_, exists := cfg.relayMap[config.MevRelayID_Agnostic].Urls[currentNetwork]
+			if exists {
+				relays = append(relays, cfg.relayMap[config.MevRelayID_Agnostic])
+			}
+		}
 	}
 
 	return relays
@@ -476,6 +488,19 @@ func createDefaultRelays() []config.MevRelay {
 				config.Network_Devnet:  "https://0xab78bf8c781c58078c3beb5710c57940874dd96aef2835e7742c866b4c7c0406754376c2c8285a36c630346aa5c5f833@goerli.aestus.live?id=staderlabs",
 			},
 			Regulated:     false,
+			NoSandwiching: false,
+		},
+		// Agnostic
+		{
+			ID:          config.MevRelayID_Agnostic,
+			Name:        "Agnostic",
+			Description: "Agnostic Relay is an open-source MEV Boost relay available to anyone, anywhere in the world, without prejudice or privilege. It is an ideal relay for block producers and block builders trying to provide neutral features.",
+			Urls: map[config.Network]string{
+				config.Network_Mainnet: "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net?id=staderlabs",
+				config.Network_Prater:  "https://0xa6bcad37b5d647152a93c2807d8a56055f1e0d7480eb6505d46edc21593e400f0f13738bf2e892f85946234629a3036a@goerli.agnostic-relay.net?id=staderlabs",
+				config.Network_Devnet:  "https://0xa6bcad37b5d647152a93c2807d8a56055f1e0d7480eb6505d46edc21593e400f0f13738bf2e892f85946234629a3036a@goerli.agnostic-relay.net?id=staderlabs",
+			},
+			Regulated:     true,
 			NoSandwiching: false,
 		},
 	}

--- a/shared/services/config/nethermind-params.go
+++ b/shared/services/config/nethermind-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	nethermindTagProd          string = "nethermind/nethermind:1.20.1"
-	nethermindTagTest          string = "nethermind/nethermind:1.20.1"
+	nethermindTagProd          string = "nethermind/nethermind:1.21.0"
+	nethermindTagTest          string = "nethermind/nethermind:1.21.0"
 	nethermindEventLogInterval int    = 1000
 	nethermindStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/nimbus-config.go
+++ b/shared/services/config/nimbus-config.go
@@ -26,13 +26,13 @@ import (
 )
 
 const (
-	// Prater
-	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v23.8.0"
-	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v23.8.0"
+	// Testnet
+	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v23.9.1"
+	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v23.9.1"
 
 	// Mainnet
-	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v23.8.0"
-	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v23.8.0"
+	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v23.9.1"
+	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v23.9.1"
 
 	defaultNimbusMaxPeersArm uint16 = 100
 	defaultNimbusMaxPeersAmd uint16 = 160

--- a/shared/services/config/prysm-config.go
+++ b/shared/services/config/prysm-config.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.0.7"
-	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.0.7"
+	prysmBnTagTest string = "gcr.io/prylabs-dev/prysm/beacon-chain:v4.1.0"
+	prysmVcTagTest string = "gcr.io/prylabs-dev/prysm/validator:v4.1.0"
 
 	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.0.7"
 	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.0.7"

--- a/shared/services/config/prysm-config.go
+++ b/shared/services/config/prysm-config.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	prysmBnTagTest string = "gcr.io/prylabs-dev/prysm/beacon-chain:v4.1.0"
-	prysmVcTagTest string = "gcr.io/prylabs-dev/prysm/validator:v4.1.0"
+	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.0.7"
+	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.0.7"
 
 	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.0.7"
 	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.0.7"

--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	tekuTagTest         string = "consensys/teku:23.8.0"
-	tekuTagProd         string = "consensys/teku:23.8.0"
+	tekuTagTest         string = "consensys/teku:23.10.0"
+	tekuTagProd         string = "consensys/teku:23.10.0"
 	defaultTekuMaxPeers uint16 = 100
 )
 

--- a/shared/services/stader/client.go
+++ b/shared/services/stader/client.go
@@ -504,12 +504,12 @@ func (c *Client) InstallService(verbose, noDeps bool, network, version, path str
 }
 
 // Install the Stader service
-func (c *Client) UpdateStaderPackage(verbose, noDeps bool, network, version, path string, dataPath string) error {
+func (c *Client) UpdateStaderPackage(verbose, noDeps bool, network, version, path, dataPath string) error {
 	return c.executeScript(verbose, noDeps, network, version, path, dataPath, UpdateURL)
 }
 
 // Install the Stader service
-func (c *Client) executeScript(verbose, noDeps bool, network, version, path string, dataPath string, url string) error {
+func (c *Client) executeScript(verbose, noDeps bool, network, version, path, dataPath, url string) error {
 
 	downloader, err := c.getDownloader()
 	if err != nil {

--- a/shared/services/stader/client.go
+++ b/shared/services/stader/client.go
@@ -499,18 +499,16 @@ func (c *Client) MigrateLegacyConfig(legacyConfigFilePath string, legacySettings
 }
 
 // Install the Stader service
-func (c *Client) InstallService(verbose, noDeps bool, network, version, path string, dataPath string) error {
+func (c *Client) InstallService(verbose, noDeps bool, network, version, path, dataPath string) error {
 	return c.executeScript(verbose, noDeps, network, version, path, dataPath, InstallerURL)
 }
 
-// Install the Stader service
+// Update the Stader package files
 func (c *Client) UpdateStaderPackage(verbose, noDeps bool, network, version, path, dataPath string) error {
 	return c.executeScript(verbose, noDeps, network, version, path, dataPath, UpdateURL)
 }
 
-// Install the Stader service
-func (c *Client) executeScript(verbose, noDeps bool, network, version, path, dataPath, url string) error {
-
+func (c *Client) executeScript(verbose, noDeps bool, network, version, path, dataPath, remoteURL string) error {
 	downloader, err := c.getDownloader()
 	if err != nil {
 		return err
@@ -532,7 +530,7 @@ func (c *Client) executeScript(verbose, noDeps bool, network, version, path, dat
 	}
 
 	// Initialize installation command
-	cmd, err := c.newCommand(fmt.Sprintf("%s %s | sh -s -- %s", downloader, fmt.Sprintf(url, version), strings.Join(flags, " ")))
+	cmd, err := c.newCommand(fmt.Sprintf("%s %s | sh -s -- %s", downloader, fmt.Sprintf(remoteURL, version), strings.Join(flags, " ")))
 
 	if err != nil {
 		return err

--- a/shared/services/stader/client.go
+++ b/shared/services/stader/client.go
@@ -56,6 +56,7 @@ import (
 // Config
 const (
 	InstallerURL = "https://staderlabs.com/eth/releases" + shared.BinaryBucket + "/%s/install.sh"
+	UpdateURL    = "https://staderlabs.com/eth/releases" + shared.BinaryBucket + "/%s/update_package.sh"
 
 	LegacyBackupFolder       string = "old_config_backup"
 	SettingsFile             string = "user-settings.yml"
@@ -499,6 +500,16 @@ func (c *Client) MigrateLegacyConfig(legacyConfigFilePath string, legacySettings
 
 // Install the Stader service
 func (c *Client) InstallService(verbose, noDeps bool, network, version, path string, dataPath string) error {
+	return c.executeScript(verbose, noDeps, network, version, path, dataPath, InstallerURL)
+}
+
+// Install the Stader service
+func (c *Client) UpdateStaderPackage(verbose, noDeps bool, network, version, path string, dataPath string) error {
+	return c.executeScript(verbose, noDeps, network, version, path, dataPath, UpdateURL)
+}
+
+// Install the Stader service
+func (c *Client) executeScript(verbose, noDeps bool, network, version, path string, dataPath string, url string) error {
 
 	downloader, err := c.getDownloader()
 	if err != nil {
@@ -521,7 +532,7 @@ func (c *Client) InstallService(verbose, noDeps bool, network, version, path str
 	}
 
 	// Initialize installation command
-	cmd, err := c.newCommand(fmt.Sprintf("%s %s | sh -s -- %s", downloader, fmt.Sprintf(InstallerURL, version), strings.Join(flags, " ")))
+	cmd, err := c.newCommand(fmt.Sprintf("%s %s | sh -s -- %s", downloader, fmt.Sprintf(url, version), strings.Join(flags, " ")))
 
 	if err != nil {
 		return err

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -2,12 +2,13 @@ package state
 
 import (
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/stader-labs/stader-node/shared/services"
 	"github.com/stader-labs/stader-node/shared/utils/stdr"
 	"github.com/stader-labs/stader-node/stader-lib/contracts"
 	"github.com/urfave/cli"
-	"math/big"
-	"time"
 
 	"github.com/stader-labs/stader-node/shared/utils/math"
 	"github.com/stader-labs/stader-node/stader-lib/utils/eth"
@@ -30,6 +31,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+const SixDecimalRound = 6
 
 type MetricDetails struct {
 	// Network details
@@ -480,14 +483,19 @@ func CreateMetricsCache(
 	metricsDetails.FrontRunValidators = frontRunValidators
 	metricsDetails.InvalidSignatureValidators = invalidSignatureValidators
 	metricsDetails.FundsSettledValidators = fundsSettledValidators
-	metricsDetails.CumulativePenalty = math.RoundDown(eth.WeiToEth(cumulativePenalty), 2)
+	metricsDetails.CumulativePenalty = math.RoundDown(eth.WeiToEth(cumulativePenalty), SixDecimalRound)
 	metricsDetails.UnclaimedClRewards = math.RoundDown(eth.WeiToEth(totalClRewards), 18)
 	metricsDetails.NextSocializingPoolRewardCycle = nextRewardCycleDetails
-	metricsDetails.UnclaimedNonSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(operatorElRewards.OperatorShare), 2)
-	metricsDetails.ClaimedSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.claimedEth), 2)
-	metricsDetails.ClaimedSocializingPoolSdRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.claimedSd), 2)
-	metricsDetails.UnclaimedSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedEth), 2)
-	metricsDetails.UnclaimedSocializingPoolSDRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedSd), 2)
+
+	// Claimed
+	metricsDetails.ClaimedSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.claimedEth), SixDecimalRound)
+	metricsDetails.ClaimedSocializingPoolSdRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.claimedSd), SixDecimalRound)
+
+	// Unclaimed
+	metricsDetails.UnclaimedNonSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(operatorElRewards.OperatorShare), SixDecimalRound)
+
+	metricsDetails.UnclaimedSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedEth), SixDecimalRound)
+	metricsDetails.UnclaimedSocializingPoolSDRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedSd), SixDecimalRound)
 
 	state.StaderNetworkDetails = metricsDetails
 

--- a/shared/types/config/types.go
+++ b/shared/types/config/types.go
@@ -112,6 +112,7 @@ const (
 	MevRelayID_Eden               MevRelayID = "eden"
 	MevRelayID_Ultrasound         MevRelayID = "ultrasound"
 	MevRelayID_Aestus             MevRelayID = "aestus"
+	MevRelayID_Agnostic           MevRelayID = "agnostic"
 )
 
 // Enum to describe MEV-Boost relay selection mode

--- a/shared/types/config/types.go
+++ b/shared/types/config/types.go
@@ -30,6 +30,8 @@ type MevRelayID string
 type MevSelectionMode string
 type NimbusPruningMode string
 
+//revive:disable
+
 // Enum to describe which container(s) a parameter impacts, so the Stadernode knows which
 // ones to restart upon a settings change
 const (
@@ -166,3 +168,5 @@ type MevRelay struct {
 	Regulated     bool
 	NoSandwiching bool
 }
+
+//revive:enable

--- a/shared/version.go
+++ b/shared/version.go
@@ -21,7 +21,7 @@ package shared
 
 const BinaryBucket string = "/stader-node-build/permissionless"
 const DockerAccount string = "staderlabs"
-const StaderVersion string = "1.4.1"
+const StaderVersion string = "1.4.2-dev"
 
 const Logo string = ` 
   _____ _            _             _           _       𝅺 	

--- a/stader-cli/service/commands.go
+++ b/stader-cli/service/commands.go
@@ -483,7 +483,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "export-eth1-data",
 				Usage:     "Exports the execution client (eth1) chain data to an external folder. Use this if you want to back up your chain data before switching execution clients.",
-				UsageText: "rocketpool service export-eth1-data target-folder",
+				UsageText: "stader-cli service export-eth1-data target-folder",
 				Flags: []cli.Flag{
 					cli.BoolFlag{
 						Name:  "force",
@@ -515,7 +515,7 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 			{
 				Name:      "import-eth1-data",
 				Usage:     "Imports execution client (eth1) chain data from an external folder. Use this if you want to restore the data from an execution client that you previously backed up.",
-				UsageText: "rocketpool service import-eth1-data source-folder",
+				UsageText: "stader-cli service import-eth1-data source-folder",
 				Action: func(c *cli.Context) error {
 
 					// Validate args

--- a/stader-cli/service/commands.go
+++ b/stader-cli/service/commands.go
@@ -182,14 +182,22 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						return err
 					}
 
-					targetUpgrades, err := migrate(c)
+					upgradesBeforeNodeStart, upgradesAftertNodeStart, err := migrate(c)
 					if err != nil {
 						return fmt.Errorf("error migrate %w", err)
 					}
+					for _, upgrader := range upgradesBeforeNodeStart {
+						fmt.Printf("Migrate before for: %s \n", upgrader.version.String())
+						err = upgrader.upgradeFunc(c)
+						if err != nil {
+							fmt.Printf("Applying upgrade for config version %s. Result: %+v", upgrader.version.String(), err.Error())
+						}
+					}
+
 					// We defer run migrate because we need stader-node api up and running first
 					defer func() {
-						for _, upgrader := range targetUpgrades {
-							fmt.Printf("Migrate for: %s \n", upgrader.version.String())
+						for _, upgrader := range upgradesAftertNodeStart {
+							fmt.Printf("Migrate after for: %s \n", upgrader.version.String())
 							err = upgrader.upgradeFunc(c)
 							if err != nil {
 								fmt.Printf("Applying upgrade for config version %s. Result: %+v", upgrader.version.String(), err.Error())
@@ -242,14 +250,23 @@ func RegisterCommands(app *cli.App, name string, aliases []string) {
 						return err
 					}
 
-					targetUpgrades, err := migrate(c)
+					upgradesBeforeNodeStart, upgradesAftertNodeStart, err := migrate(c)
 					if err != nil {
 						return fmt.Errorf("error migrate %w", err)
 					}
+
+					for _, upgrader := range upgradesBeforeNodeStart {
+						fmt.Printf("Migrate before for: %s \n", upgrader.version.String())
+						err = upgrader.upgradeFunc(c)
+						if err != nil {
+							fmt.Printf("Applying upgrade for config version %s. Result: %+v", upgrader.version.String(), err.Error())
+						}
+					}
+
 					// We defer run migrate because we need stader-node api up and running first
 					defer func() {
-						for _, upgrader := range targetUpgrades {
-							fmt.Printf("Migrate for: %s \n", upgrader.version.String())
+						for _, upgrader := range upgradesAftertNodeStart {
+							fmt.Printf("Migrate after for: %s \n", upgrader.version.String())
 							err = upgrader.upgradeFunc(c)
 							if err != nil {
 								fmt.Printf("error applying upgrade for config version %s: %+v", upgrader.version.String(), err)

--- a/stader-cli/service/config.go
+++ b/stader-cli/service/config.go
@@ -180,9 +180,15 @@ func configureService(c *cli.Context) error {
 }
 
 func isUpgradeBinary(c *cli.Context) (bool, error) {
-	cfg, err := loadConfig(c)
+	staderClient, err := stader.NewClientFromCtx(c)
 	if err != nil {
-		return false, fmt.Errorf("error loading user settings: %w", err)
+		return false, fmt.Errorf("error NewClientFromCtx: %w", err)
+	}
+	defer staderClient.Close()
+
+	cfg, _, err := staderClient.LoadConfig()
+	if err != nil {
+		return false, fmt.Errorf("error LoadConfig: %w", err)
 	}
 
 	// cfg nill or version empty in case fresh install

--- a/stader-cli/service/configExecution.go
+++ b/stader-cli/service/configExecution.go
@@ -62,6 +62,7 @@ func updateLocalExecutionClient(cfg *stdCf.StaderConfig, newSettings map[string]
 	cfg.Geth.MaxPeers.Value = newSettings[keys.E1ec_lm_geth_max_peers]
 	cfg.Geth.ContainerTag.Value = newSettings[keys.E1ec_lm_geth_container_tag]
 	cfg.Geth.AdditionalFlags.Value = newSettings[keys.E1ec_lm_geth_additional_flags]
+	cfg.Geth.EnablePbss.Value = newSettings[keys.E1ec_lm_geth_enable_pbsm]
 
 	// Nethermind
 	cfg.Nethermind.CacheSize.Value = newSettings[keys.E1ec_lm_nethermind_cache_size]
@@ -104,6 +105,8 @@ func setUIExecutionClient(cfg *stdCf.StaderConfig, newSettings map[string]interf
 	newSettings[keys.E1ec_lm_geth_max_peers] = format(cfg.Geth.MaxPeers.Value)
 	newSettings[keys.E1ec_lm_geth_container_tag] = cfg.Geth.ContainerTag.Value
 	newSettings[keys.E1ec_lm_geth_additional_flags] = cfg.Geth.AdditionalFlags.Value
+	newSettings[keys.E1ec_lm_geth_enable_pbsm] =
+		cfg.Geth.EnablePbss.Value
 
 	// Nethermind
 	newSettings[keys.E1ec_lm_nethermind_cache_size] = format(cfg.Nethermind.CacheSize.Value)

--- a/stader-cli/service/configMEVBoost.go
+++ b/stader-cli/service/configMEVBoost.go
@@ -56,8 +56,11 @@ func setUIMEVBoost(cfg *stdCf.StaderConfig, newSettings map[string]interface{}) 
 	newSettings[keys.Mev_boost_rm_container_tag] = cfg.MevBoost.ContainerTag.Value
 	newSettings[keys.Mev_boost_rm_additional_flags] = cfg.MevBoost.AdditionalFlags.Value
 
-	v, _ := cfg.MevBoost.AestusRelay.Value.(bool)
-	newSettings[keys.Mev_boost_rm_enable_aestus] = v
+	enableAestus, _ := cfg.MevBoost.AestusRelay.Value.(bool)
+	newSettings[keys.Mev_boost_rm_enable_aestus] = enableAestus
+
+	enableAgnostic, _ := cfg.MevBoost.AgnosticRelay.Value.(bool)
+	newSettings[keys.Mev_boost_rm_enable_agnostic] = enableAgnostic
 
 	newSettings[keys.Mev_boost_rm_enable_bloXroute_regulated] = cfg.MevBoost.BloxRouteRegulatedRelay.Value.(bool)
 
@@ -87,6 +90,8 @@ func updateMEVBoost(cfg *stdCf.StaderConfig, newSettings map[string]interface{})
 
 	cfg.MevBoost.BloxRouteRegulatedRelay.Value = newSettings[keys.Mev_boost_rm_enable_bloXroute_regulated]
 	cfg.MevBoost.AestusRelay.Value = newSettings[keys.Mev_boost_rm_enable_aestus]
+
+	cfg.MevBoost.AgnosticRelay.Value = newSettings[keys.Mev_boost_rm_enable_agnostic]
 
 	switch mevSelection {
 	case cfgtypes.MevSelectionMode_Profile:

--- a/stader-cli/service/migration.go
+++ b/stader-cli/service/migration.go
@@ -176,7 +176,7 @@ func install(c *cli.Context) error {
 		return fmt.Errorf("error getting data path from old configuration: %w", err)
 	}
 
-	err = staderClient.InstallService(
+	err = staderClient.UpdateStaderPackage(
 		false,
 		true,
 		fmt.Sprintf("%s", cfg.StaderNode.Network.Value),
@@ -188,6 +188,5 @@ func install(c *cli.Context) error {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)
 	}
 
-	// Remove the upgrade flag if it's there
-	return staderClient.RemoveUpgradeFlagFile()
+	return nil
 }

--- a/stader-cli/service/migration.go
+++ b/stader-cli/service/migration.go
@@ -5,75 +5,115 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-version"
+	"github.com/mitchellh/go-homedir"
+	"github.com/stader-labs/stader-node/shared"
 	"github.com/stader-labs/stader-node/shared/services/stader"
 	"github.com/urfave/cli"
 )
 
 type ConfigUpgrader struct {
-	version     *version.Version
-	upgradeFunc func(c *cli.Context) error
+	version                 *version.Version
+	upgradeFunc             func(c *cli.Context) error
+	needInstall             bool
+	runAfterStaderNodeStart bool
 }
 
 //go:embed guardian.tmpl
 var guardian []byte
 
-func migrate(c *cli.Context) ([]ConfigUpgrader, error) {
+func migrate(c *cli.Context) (runBeforeUpgrades, rundAfterUpgrades []ConfigUpgrader, err error) {
+	v0, _ := parseVersion("1.0.0")
+
 	// Create versions
 	v130, err := parseVersion("1.3.0")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Create versions
 	v140, err := parseVersion("1.4.0")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	// Create versions
+	v142, err := parseVersion("1.4.2")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Create the collection of upgraders
 	upgraders := []ConfigUpgrader{
 		{
-			version:     v130,
-			upgradeFunc: upgradeFuncV30,
+			version:                 v130,
+			upgradeFunc:             upgradeFuncV30,
+			runAfterStaderNodeStart: true,
 		},
 		{
 			version:     v140,
 			upgradeFunc: upgradeFuncV140,
 		},
+		{
+			version:     v142,
+			upgradeFunc: func(c *cli.Context) error { return nil },
+			needInstall: true,
+		},
 	}
 
-	cfg, err := loadConfig(c)
+	staderClient, err := stader.NewClientFromCtx(c)
 	if err != nil {
-		return nil, fmt.Errorf("error loading user settings: %w", err)
+		return nil, nil, fmt.Errorf("error NewClientFromCtx: %w", err)
+	}
+
+	defer staderClient.Close()
+
+	cfg, _, err := staderClient.LoadConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error loading user settings: %w", err)
 	}
 
 	// cfg nill or version empty in case fresh install
 	if cfg == nil || len(cfg.Version) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	cfgVer, err := parseVersion(cfg.Version)
 	if err != nil {
-		return nil, fmt.Errorf("error checking for config version: %w", err)
+		return nil, nil, fmt.Errorf("error checking for config version: %w", err)
 	}
 
 	// Find the index of the provided config's version
-	var targetUpgrades []ConfigUpgrader
+	var needInstall bool
 	for _, upgrader := range upgraders {
 		cfgVerCore := cfgVer.Core()
 		targetVerCore := upgrader.version.Core()
 
 		if cfgVerCore.LessThan(targetVerCore) {
-			targetUpgrades = append(targetUpgrades, upgrader)
+			if upgrader.runAfterStaderNodeStart {
+				rundAfterUpgrades = append(rundAfterUpgrades, upgrader)
+			} else {
+				runBeforeUpgrades = append(runBeforeUpgrades, upgrader)
+			}
+
+			needInstall = needInstall || upgrader.needInstall
 		}
 	}
 
-	// If there are no upgrades to apply, return
-	if len(targetUpgrades) == 0 {
-		return nil, nil
+	if needInstall {
+		runBeforeUpgrades = append([]ConfigUpgrader{
+			{
+				upgradeFunc: install,
+				version:     v0,
+			},
+		}, runBeforeUpgrades...)
 	}
 
-	return targetUpgrades, nil
+	// If there are no upgrades to apply, return
+	if len(runBeforeUpgrades) == 0 && len(rundAfterUpgrades) == 0 {
+		return nil, nil, nil
+	}
+
+	return runBeforeUpgrades, rundAfterUpgrades, nil
 }
 
 func upgradeFuncV30(c *cli.Context) error {
@@ -81,8 +121,8 @@ func upgradeFuncV30(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)
 	}
-	_, err = staderClient.RebuildWallet()
 
+	_, err = staderClient.RebuildWallet()
 	if err != nil {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)
 	}
@@ -95,11 +135,59 @@ func upgradeFuncV140(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)
 	}
-	err = staderClient.UpdateGuardianConfiguration(guardian)
 
+	err = staderClient.UpdateGuardianConfiguration(guardian)
 	if err != nil {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)
 	}
 
 	return nil
+}
+
+func install(c *cli.Context) error {
+	staderClient, err := stader.NewClientFromCtx(c)
+	if err != nil {
+		return fmt.Errorf("error NewClientFromCtx: %w", err)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error NewClientFromCtx: %w", err)
+	}
+	defer staderClient.Close()
+
+	cfg, _, err := staderClient.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("error LoadConfig: %w", err)
+	}
+
+	dataPath, ok := cfg.StaderNode.DataPath.Value.(string)
+	if !ok {
+		return fmt.Errorf("error path: %s", cfg.StaderNode.DataPath.Value)
+	}
+
+	dataPath, err = homedir.Expand(dataPath)
+	if err != nil {
+		return fmt.Errorf("error getting data path from old configuration: %w", err)
+	}
+
+	// Install service
+	path, err := homedir.Expand(cfg.StaderDirectory)
+	if err != nil {
+		return fmt.Errorf("error getting data path from old configuration: %w", err)
+	}
+
+	err = staderClient.InstallService(
+		false,
+		true,
+		fmt.Sprintf("%s", cfg.StaderNode.Network.Value),
+		fmt.Sprintf("v%s", shared.StaderVersion),
+		path,
+		dataPath,
+	)
+	if err != nil {
+		return fmt.Errorf("error NewClientFromCtx: %w", err)
+	}
+
+	// Remove the upgrade flag if it's there
+	return staderClient.RemoveUpgradeFlagFile()
 }

--- a/stader-cli/service/migration.go
+++ b/stader-cli/service/migration.go
@@ -102,7 +102,7 @@ func migrate(c *cli.Context) (runBeforeUpgrades, rundAfterUpgrades []ConfigUpgra
 	if needInstall {
 		runBeforeUpgrades = append([]ConfigUpgrader{
 			{
-				upgradeFunc: install,
+				upgradeFunc: updateStaderPackage,
 				version:     v0,
 			},
 		}, runBeforeUpgrades...)
@@ -144,7 +144,7 @@ func upgradeFuncV140(c *cli.Context) error {
 	return nil
 }
 
-func install(c *cli.Context) error {
+func updateStaderPackage(c *cli.Context) error {
 	staderClient, err := stader.NewClientFromCtx(c)
 	if err != nil {
 		return fmt.Errorf("error NewClientFromCtx: %w", err)

--- a/update_package.sh
+++ b/update_package.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+# This work is licensed and released under GNU GPL v3 or any other later versions. 
+# The full text of the license is below/ found at <http://www.gnu.org/licenses/>
+
+# (c) 2023 Rocket Pool Pty Ltd. Modified under GNU GPL v3. [1.4.1]
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+##
+# Stader service installation script
+# Prints progress messages to stdout
+# All command output is redirected to stderr
+##
+
+COLOR_RED='\033[0;31m'
+COLOR_YELLOW='\033[33m'
+COLOR_RESET='\033[0m'
+
+# Print a failure message to stderr and exit
+fail() {
+    MESSAGE=$1
+    >&2 echo -e "\n${COLOR_RED}**ERROR**\n$MESSAGE${COLOR_RESET}"
+    exit 1
+}
+
+
+# Get CPU architecture
+UNAME_VAL=$(uname -m)
+ARCH=""
+case $UNAME_VAL in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    arm64)   ARCH="arm64" ;;
+    *)       fail "CPU architecture not supported: $UNAME_VAL" ;;
+esac
+
+
+# Get the platform type
+PLATFORM=$(uname -s)
+if [ "$PLATFORM" = "Linux" ]; then
+    if command -v lsb_release &>/dev/null ; then
+        PLATFORM=$(lsb_release -si)
+    elif [ -f "/etc/centos-release" ]; then
+        PLATFORM="CentOS"
+    elif [ -f "/etc/fedora-release" ]; then
+        PLATFORM="Fedora"
+    fi
+fi
+
+##
+# Config
+##
+
+
+# The total number of steps in the installation process
+TOTAL_STEPS="2"
+# The Stader user data path
+STADER_PATH="$HOME/.stader"
+# The default stader node package version to download
+PACKAGE_VERSION="latest"
+# The default network to run Stader on
+NETWORK="mainnet"
+
+##
+# Utils
+##
+
+
+# Print progress
+progress() {
+    STEP_NUMBER=$1
+    MESSAGE=$2
+    echo "Step $STEP_NUMBER of $TOTAL_STEPS: $MESSAGE"
+}
+
+
+# Docker installation steps
+add_user_docker() {
+    $SUDO_CMD usermod -aG docker $USER || fail "Could not add user to docker group."
+}
+
+
+# Detect installed privilege escalation programs
+get_escalation_cmd() {
+    if type sudo > /dev/null 2>&1; then
+        SUDO_CMD="sudo"
+    elif type doas > /dev/null 2>&1; then
+        echo "NOTE: sudo not found, using doas instead"
+        SUDO_CMD="doas"
+    else
+        fail "Please make sure a privilege escalation command such as \"sudo\" is installed and available before installing Stader."
+    fi
+}
+
+# Install
+install() {
+
+
+##
+# Initialization
+##
+
+
+# Parse arguments
+while getopts "dp:u:n:v:" FLAG; do
+    case "$FLAG" in
+        d) NO_DEPS=true ;;
+        p) STADER_PATH="$OPTARG" ;;
+        u) DATA_PATH="$OPTARG" ;;
+        n) NETWORK="$OPTARG" ;;
+        v) PACKAGE_VERSION="$OPTARG" ;;
+        *) fail "Incorrect usage." ;;
+    esac
+done
+
+if [ -z "$DATA_PATH" ]; then
+    DATA_PATH="$STADER_PATH/data"
+fi
+
+if [ "$PACKAGE_VERSION" = "latest" ]; then
+    PACKAGE_URL="https://staderlabs.com/eth/releases/stader-node-build/permissionless/latest/stader-node-install.tar.xz"
+else
+    PACKAGE_URL="https://staderlabs.com/eth/releases/stader-node-build/permissionless/$PACKAGE_VERSION/stader-node-install.tar.xz"
+fi
+
+# Create temporary data folder; clean up on exit
+TEMPDIR=$(mktemp -d 2>/dev/null) || fail "Could not create temporary data directory."
+trap 'rm -rf "$TEMPDIR"' EXIT
+
+
+# Get temporary data paths
+PACKAGE_FILES_PATH="$TEMPDIR/install"
+
+
+##
+# Installation
+##
+
+# Check for existing installation
+progress 1 "Checking for existing installation..."
+if [ -d $STADER_PATH ]; then
+    # Check for legacy files - key on the old config.yml
+    if [ -f "$STADER_PATH/config.yml" ]; then
+        progress 1 "Old installation detected, backing it up and migrating to new config system..."
+        OLD_CONFIG_BACKUP_PATH="$STADER_PATH/old_config_backup"
+        { mkdir -p $OLD_CONFIG_BACKUP_PATH || fail "Could not create old config backup folder."; } >&2
+
+        if [ -f "$STADER_PATH/config.yml" ]; then
+            { mv "$STADER_PATH/config.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move config.yml to backup folder."; } >&2
+        fi
+        if [ -f "$STADER_PATH/settings.yml" ]; then
+            { mv "$STADER_PATH/settings.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move settings.yml to backup folder."; } >&2
+        fi
+        if [ -f "$STADER_PATH/docker-compose.yml" ]; then
+            { mv "$STADER_PATH/docker-compose.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move docker-compose.yml to backup folder."; } >&2
+        fi
+        if [ -f "$STADER_PATH/docker-compose-metrics.yml" ]; then
+            { mv "$STADER_PATH/docker-compose-metrics.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move docker-compose-metrics.yml to backup folder."; } >&2
+        fi
+        if [ -f "$STADER_PATH/docker-compose-fallback.yml" ]; then
+            { mv "$STADER_PATH/docker-compose-fallback.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move docker-compose-fallback.yml to backup folder."; }>&2
+        fi
+        if [ -f "$STADER_PATH/prometheus.tmpl" ]; then
+            { mv "$STADER_PATH/prometheus.tmpl" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move prometheus.tmpl to backup folder."; } >&2
+        fi
+        if [ -f "$STADER_PATH/grafana-prometheus-datasource.yml" ]; then
+            { mv "$STADER_PATH/grafana-prometheus-datasource.yml" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move grafana-prometheus-datasource.yml to backupfolder."; } >&2
+        fi
+        if [ -d "$STADER_PATH/chains" ]; then
+            { mv "$STADER_PATH/chains" "$OLD_CONFIG_BACKUP_PATH" || fail "Could not move chains directory to backup folder."; } >&2
+        fi
+    fi
+
+    # Back up existing config file
+    if [ -f "$STADER_PATH/user-settings.yml" ]; then
+        progress 1 "Backing up configuration settings to user-settings-backup.yml..."
+        { cp "$STADER_PATH/user-settings.yml" "$STADER_PATH/user-settings-backup.yml" || fail "Could not backup configuration settings."; } >&2
+    fi
+fi
+
+
+# Download and extract package files
+progress 2 "Downloading Stader package files..."
+{ curl -L "$PACKAGE_URL" | tar -xJ -C "$TEMPDIR" || fail "Could not download and extract the Stader package files."; } >&2
+{ test -d "$PACKAGE_FILES_PATH" || fail "Could not extract the Stader package files."; } >&2
+
+
+# Copy package files
+progress 2 "Copying package files to Stader user data directory..."
+{ cp -r -n "$PACKAGE_FILES_PATH/override" "$STADER_PATH" || rsync -r --ignore-existing "$PACKAGE_FILES_PATH/override" "$STADER_PATH" || fail "Could not copy new override files to the Stader user data directory."; } >&2
+{ cp -r "$PACKAGE_FILES_PATH/scripts" "$STADER_PATH" || fail "Could not copy scripts folder to the Stader user data directory."; } >&2
+{ cp -r "$PACKAGE_FILES_PATH/templates" "$STADER_PATH" || fail "Could not copy templates folder to the Stader user data directory."; } >&2
+{ cp "$PACKAGE_FILES_PATH/grafana-prometheus-datasource.yml" "$PACKAGE_FILES_PATH/prometheus.tmpl" "$STADER_PATH" || fail "Could not copy base files to the Stader user data directory."; } >&2
+{ find "$STADER_PATH/scripts" -name "*.sh" -exec chmod +x {} \; 2>/dev/null || fail "Could not set executable permissions on package files."; } >&2
+
+# Clean up unnecessary files from old installations
+progress 2 "Cleaning up obsolete files from previous installs..."
+
+}
+
+install "$@"


### PR DESCRIPTION
### What's in this PR:

* Udate clients as following:
   - Geth:v1.13.4
   - Nethermind:1.21.0
   - Besu:23.10.0
   - Prysm:v4.0.7
   - Lighthouse:v4.5.0
   - Teku:23.10.0
   - Lodestar:v1.11.3
 
* Support new geth state store in geth 1.13.4

* Agnostic MEV support

* Fix Grafana UI issue due to round decimals