### PR TITLE
Only saved config after service start

### DIFF
--- a/stader/node/manage-fee-recipient.go
+++ b/stader/node/manage-fee-recipient.go
@@ -144,7 +144,7 @@ func (m *manageFeeRecipient) run() error {
 
 	nextUpdatableBlock := lastChangeBlock.Add(lastChangeBlock, big.NewInt(blocksPerThreeEpoch)).Uint64()
 
-	m.log.Printlnf("CurrentBlock: %d, we'll update file at %d block if possible\n", nextUpdatableBlock)
+	m.log.Printlnf("CurrentBlock: %d, we'll update file at %d block if possible\n", currentBlock, nextUpdatableBlock)
 
 	// Get the fee recipient info for the node
 	feeRecipientInfo, err := staderUtils.GetFeeRecipientInfo(m.prn, m.vf, m.sdcfg, nodeAccount.Address, nil)


### PR DESCRIPTION
### What's in this PR:

* Currently we saved config version right after run migration. This'll make any post-load config see the new version.
This's not expected, we should only do that after service start.
* Fix the missing print