### PR TITLE
Add metrics

### DIFF
--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stader-labs/stader-node/shared/services"
 	"github.com/stader-labs/stader-node/shared/utils/stdr"
 	"github.com/stader-labs/stader-node/stader-lib/contracts"
+	"github.com/stader-labs/stader-node/stader-lib/sdutility"
 	"github.com/urfave/cli"
 
 	"github.com/stader-labs/stader-node/shared/utils/math"
@@ -114,6 +115,9 @@ type MetricDetails struct {
 	OperatorStakedSdInEth float64
 	// done
 	OperatorEthCollateral float64
+
+	// done
+	OperatorSDUtilized float64
 }
 
 type MetricsCache struct {
@@ -153,6 +157,11 @@ func CreateMetricsCache(
 	if err != nil {
 		return nil, err
 	}
+
+	sduAddress, err := services.GetSdUtilityAddress(c)
+	// if err != nil {
+	// 	return nil, err
+	// }
 	ethxAddress, err := services.GetEthxTokenAddress(c)
 	if err != nil {
 		return nil, err
@@ -208,6 +217,11 @@ func CreateMetricsCache(
 		return nil, err
 	}
 	sp, err := stader.NewSocializingPool(ec, socializingPoolAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	sdu, err := stader.NewSDUtilityPool(ec, sduAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -449,6 +463,11 @@ func CreateMetricsCache(
 		return nil, err
 	}
 
+	sdUtilized, err := sdutility.GetUtilizerLatestBalance(sdu, nodeAddress, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	minThreshold := math.RoundDown(eth.WeiToEth(permissionlessPoolThreshold.MinThreshold), 2)
 	sdPriceFormatted := math.RoundDown(eth.WeiToEth(sdPrice), 2)
 	collateralRatioInSd := minThreshold * sdPriceFormatted
@@ -497,6 +516,7 @@ func CreateMetricsCache(
 	metricsDetails.UnclaimedSocializingPoolElRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedEth), SixDecimalRound)
 	metricsDetails.UnclaimedSocializingPoolSDRewards = math.RoundDown(eth.WeiToEth(rewardClaimData.unclaimedSd), SixDecimalRound)
 
+	metricsDetails.OperatorSDUtilized = math.RoundDown(eth.WeiToEth(sdUtilized), SixDecimalRound)
 	state.StaderNetworkDetails = metricsDetails
 
 	state.logLine("Retrieved Stader Network Details (total time: %s)", time.Since(start))

--- a/shared/services/state/network-state.go
+++ b/shared/services/state/network-state.go
@@ -159,9 +159,9 @@ func CreateMetricsCache(
 	}
 
 	sduAddress, err := services.GetSdUtilityAddress(c)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	if err != nil {
+		return nil, err
+	}
 	ethxAddress, err := services.GetEthxTokenAddress(c)
 	if err != nil {
 		return nil, err

--- a/stader-cli/validator/deposit.go
+++ b/stader-cli/validator/deposit.go
@@ -15,8 +15,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-const Decimal = 18
-
 func nodeDeposit(c *cli.Context) error {
 
 	staderClient, err := stader.NewClientFromCtx(c)
@@ -67,7 +65,7 @@ func nodeDeposit(c *cli.Context) error {
 		log.ColorBlue,
 		status.AccountAddress,
 		log.ColorReset,
-		math.RoundDown(eth.WeiToEth(status.AccountBalances.Sd), Decimal))
+		math.RoundDown(eth.WeiToEth(status.AccountBalances.Sd), eth.Decimal))
 
 	canNodeDepositResponse, err := staderClient.CanNodeDeposit(baseAmount, big.NewInt(0), big.NewInt(int64(numValidators)), true)
 	if err != nil {
@@ -85,43 +83,6 @@ func nodeDeposit(c *cli.Context) error {
 
 	sdStatus := canNodeDepositResponse.SdStatusResponse
 	amountToCollateral := new(big.Int).Sub(sdStatus.SdCollateralRequireAmount, sdStatus.SdCollateralCurrentAmount)
-
-	fmt.Printf(
-		"The node %s%s%s current had %.6f SD in collateral.\n\n",
-		log.ColorBlue,
-		status.AccountAddress,
-		log.ColorReset,
-		math.RoundDown(eth.WeiToEth(sdStatus.SdCollateralCurrentAmount), Decimal))
-
-	fmt.Printf(
-		"The node %s%s%s need %.6f SD in collateral after deposit.\n\n",
-		log.ColorBlue,
-		status.AccountAddress,
-		log.ColorReset,
-		math.RoundDown(eth.WeiToEth(sdStatus.SdCollateralRequireAmount), Decimal))
-
-	fmt.Printf(
-		"The node %s%s%s can had max %.6f SD in collateral after deposit.\n\n",
-		log.ColorBlue,
-		status.AccountAddress,
-		log.ColorReset,
-		math.RoundDown(eth.WeiToEth(sdStatus.SdMaxCollateralAmount), Decimal))
-
-	fmt.Printf(
-		"The node %s%s%s current utility %.6f SD.\n\n",
-		log.ColorBlue,
-		status.AccountAddress,
-		log.ColorReset,
-		math.RoundDown(eth.WeiToEth(sdStatus.SdUtilizerLatestBalance), Decimal))
-
-	if amountToCollateral.Cmp(big.NewInt(0)) >= 1 {
-		fmt.Printf(
-			"The node %s%s%s need %.6f SD to meet collateral require.\n\n",
-			log.ColorBlue,
-			status.AccountAddress,
-			log.ColorReset,
-			math.RoundDown(eth.WeiToEth(amountToCollateral), Decimal))
-	}
 
 	utilityAmount := big.NewInt(0)
 

--- a/stader-lib/utils/eth/units.go
+++ b/stader-lib/utils/eth/units.go
@@ -28,6 +28,7 @@ import (
 const (
 	WeiPerEth  float64 = 1e18
 	WeiPerGwei float64 = 1e9
+	Decimal            = 18
 )
 
 // Convert wei to eth

--- a/stader/guardian/collector/constants.go
+++ b/stader/guardian/collector/constants.go
@@ -29,6 +29,7 @@ const UnclaimedSocializingPoolELRewards = "unclaimed_socializing_pool_el_rewards
 const UnclaimedSocializingPoolSdRewards = "unclaimed_socializing_pool_sd_rewards"
 const UnclaimedCLRewards = "unclaimed_cl_rewards"
 const NextRewardCycleTime = "next_reward_cycle_time"
+const SDUtilized = "sd_utilized"
 
 // Node Health => stader_node_health+ key
 const NodeSub = "node_health"

--- a/stader/guardian/collector/operator-collector.go
+++ b/stader/guardian/collector/operator-collector.go
@@ -33,6 +33,7 @@ type OperatorCollector struct {
 	TotalSdCollateral                    *prometheus.Desc
 	TotalSdCollateralInEth               *prometheus.Desc
 	TotalEthColateral                    *prometheus.Desc
+	TotalSDUtilized                      *prometheus.Desc
 
 	// The beacon client
 	bc beacon.Client
@@ -112,6 +113,8 @@ func NewOperatorCollector(
 			prometheus.BuildFQName(namespace, OperatorSub, SdCollateralInEth), "", nil, nil),
 		TotalEthColateral: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, OperatorSub, EthCollateral), "", nil, nil),
+		TotalSDUtilized: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, OperatorSub, SDUtilized), "", nil, nil),
 		bc:          bc,
 		ec:          ec,
 		nodeAddress: nodeAddress,
@@ -142,6 +145,7 @@ func (collector *OperatorCollector) Describe(channel chan<- *prometheus.Desc) {
 	channel <- collector.TotalSdCollateral
 	channel <- collector.TotalSdCollateralInEth
 	channel <- collector.TotalEthColateral
+	channel <- collector.TotalSDUtilized
 }
 
 // Collect the latest metric values and pass them to Prometheus
@@ -169,7 +173,7 @@ func (collector *OperatorCollector) Collect(channel chan<- prometheus.Metric) {
 	channel <- prometheus.MustNewConstMetric(collector.TotalSdCollateral, prometheus.GaugeValue, state.StaderNetworkDetails.OperatorStakedSd)
 	channel <- prometheus.MustNewConstMetric(collector.TotalSdCollateralInEth, prometheus.GaugeValue, state.StaderNetworkDetails.OperatorStakedSdInEth)
 	channel <- prometheus.MustNewConstMetric(collector.TotalEthColateral, prometheus.GaugeValue, state.StaderNetworkDetails.OperatorEthCollateral)
-
+	channel <- prometheus.MustNewConstMetric(collector.TotalSDUtilized, prometheus.GaugeValue, state.StaderNetworkDetails.OperatorSDUtilized)
 }
 
 // Log error messages

--- a/stader/guardian/collector/state-locker.go
+++ b/stader/guardian/collector/state-locker.go
@@ -1,9 +1,10 @@
 package collector
 
 import (
-	"github.com/stader-labs/stader-node/stader-lib/contracts"
 	"math/big"
 	"sync"
+
+	"github.com/stader-labs/stader-node/stader-lib/contracts"
 
 	"github.com/stader-labs/stader-node/shared/services/beacon"
 	"github.com/stader-labs/stader-node/shared/services/state"
@@ -53,10 +54,12 @@ func NewMetricsCacheContainer() *MetricsCacheContainer {
 					CurrentStartBlock: big.NewInt(0),
 					CurrentEndBlock:   big.NewInt(0),
 				},
-				ValidatorStatusMap:  make(map[types.ValidatorPubkey]beacon.ValidatorStatus),
-				ValidatorInfoMap:    make(map[types.ValidatorPubkey]contracts.Validator),
-				CollateralRatio:     0,
-				CollateralRatioInSd: 0,
+				ValidatorStatusMap:     make(map[types.ValidatorPubkey]beacon.ValidatorStatus),
+				ValidatorInfoMap:       make(map[types.ValidatorPubkey]contracts.Validator),
+				CollateralRatio:        0,
+				CollateralRatioInSd:    0,
+				OperatorSDUtilized:     0,
+				StaderQueuedValidators: big.NewInt(0),
 			},
 		},
 	}


### PR DESCRIPTION
### What's in this PR:

* Add SD utilized metrics
* Fix guardian node crash if `metrics` endpoind hit before `Retrieved Stader Network Details`