### PR TITLE
fix sp rewards precision issue

### DIFF
--- a/stader-cli/node/claim-sp-rewards.go
+++ b/stader-cli/node/claim-sp-rewards.go
@@ -2,15 +2,16 @@ package node
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
 	"github.com/stader-labs/stader-node/shared/services/gas"
 	"github.com/stader-labs/stader-node/shared/services/stader"
 	cliutils "github.com/stader-labs/stader-node/shared/utils/cli"
 	"github.com/stader-labs/stader-node/shared/utils/math"
 	"github.com/stader-labs/stader-node/stader-lib/utils/eth"
 	"github.com/urfave/cli"
-	"math/big"
-	"strconv"
-	"strings"
 )
 
 func ClaimSpRewards(c *cli.Context) error {
@@ -75,12 +76,12 @@ func ClaimSpRewards(c *cli.Context) error {
 			if !ok {
 				return fmt.Errorf("Unable to parse eth rewards: %s", cycleInfo.MerkleProofInfo.Eth)
 			}
-			ethRewardsConverted := math.RoundDown(eth.WeiToEth(ethRewards), 2)
+			ethRewardsConverted := math.RoundDown(eth.WeiToEth(ethRewards), 5)
 			sdRewards, ok := big.NewInt(0).SetString(cycleInfo.MerkleProofInfo.Sd, 10)
 			if !ok {
 				return fmt.Errorf("Unable to parse sd rewards: %s", cycleInfo.MerkleProofInfo.Sd)
 			}
-			sdRewardsConverted := math.RoundDown(eth.WeiToEth(sdRewards), 2)
+			sdRewardsConverted := math.RoundDown(eth.WeiToEth(sdRewards), 5)
 
 			if ethRewardsConverted == 0 && sdRewardsConverted == 0 {
 				continue

--- a/stader-cli/node/claim-sp-rewards.go
+++ b/stader-cli/node/claim-sp-rewards.go
@@ -83,7 +83,7 @@ func ClaimSpRewards(c *cli.Context) error {
 			}
 			sdRewardsConverted := math.RoundDown(eth.WeiToEth(sdRewards), 5)
 
-			if ethRewardsConverted == 0 && sdRewardsConverted == 0 {
+			if ethRewards.Cmp(big.NewInt(0)) == 0 && sdRewards.Cmp(big.NewInt(0)) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
If the socializing pool rewards is very low, it gets rounded down to 0 and will not appear in the claimable rewards list. To fix this increase the precision of the socializing pool rewards