### PR TITLE
Enable doppleganger protection for teku + version update

### DIFF
--- a/install/scripts/start-bn.sh
+++ b/install/scripts/start-bn.sh
@@ -318,6 +318,7 @@ if [ "$CC_CLIENT" = "teku" ]; then
         --eth1-deposit-contract-max-request-size=150 \
         --log-destination=CONSOLE \
         --ee-jwt-secret-file=/secrets/jwtsecret \
+        --beacon-liveness-tracking-enabled \
         $BN_ADDITIONAL_FLAGS"
 
     if [ "$TEKU_ARCHIVE_MODE" = "true" ]; then
@@ -337,7 +338,7 @@ if [ "$CC_CLIENT" = "teku" ]; then
     fi
 
     if [ ! -z "$CHECKPOINT_SYNC_URL" ]; then
-        CMD="$CMD --initial-state=$CHECKPOINT_SYNC_URL/eth/v2/debug/beacon/states/finalized"
+        CMD="$CMD --checkpoint-sync-url=$CHECKPOINT_SYNC_URL"
     elif [ "$NETWORK" = "zhejiang" ]; then
         CMD="$CMD --initial-state=/zhejiang/genesis.ssz"
     fi

--- a/install/scripts/start-vc.sh
+++ b/install/scripts/start-vc.sh
@@ -265,6 +265,10 @@ if [ "$CC_CLIENT" = "teku" ]; then
         CMD="$CMD --metrics-publish-endpoint=$BITFLY_NODE_METRICS_ENDPOINT?apikey=$BITFLY_NODE_METRICS_SECRET&machine=$BITFLY_NODE_METRICS_MACHINE_NAME"
     fi
 
+    if [ "$DOPPELGANGER_DETECTION" = "true" ]; then
+        CMD="$CMD --doppelganger-detection-enabled"
+    fi
+
     exec ${CMD} --validators-graffiti="$GRAFFITI"
 
 fi

--- a/shared/services/config/besu-params.go
+++ b/shared/services/config/besu-params.go
@@ -25,8 +25,8 @@ import (
 
 // Constants
 const (
-	besuTagTest          string = "hyperledger/besu:23.10.0"
-	besuTagProd          string = "hyperledger/besu:23.10.0"
+	besuTagTest          string = "hyperledger/besu:23.10.2"
+	besuTagProd          string = "hyperledger/besu:23.10.2"
 	besuEventLogInterval int    = 1000
 	besuMaxPeers         uint16 = 25
 	besuStopSignal       string = "SIGTERM"

--- a/shared/services/config/external-configs.go
+++ b/shared/services/config/external-configs.go
@@ -112,6 +112,9 @@ type ExternalTekuConfig struct {
 
 	// Custom command line flags for the VC
 	AdditionalVcFlags config.Parameter `yaml:"additionalVcFlags,omitempty"`
+
+	// Toggle for enabling doppelganger detection
+	DoppelgangerDetection config.Parameter `yaml:"doppelgangerDetection,omitempty"`
 }
 
 type ExternalLodestarConfig struct {
@@ -454,6 +457,17 @@ func NewExternalTekuConfig(cfg *StaderConfig) *ExternalTekuConfig {
 			CanBeBlank:           true,
 			OverwriteOnUpgrade:   false,
 		},
+		DoppelgangerDetection: config.Parameter{
+			ID:                   DoppelgangerDetectionID,
+			Name:                 "Enable Doppelgänger Detection",
+			Description:          "If enabled, your client will *intentionally* miss 1 or 2 attestations on startup to check if validator keys are already running elsewhere. If they are, it will disable validation duties for them to prevent you from being slashed.",
+			Type:                 config.ParameterType_Bool,
+			Default:              map[config.Network]interface{}{config.Network_All: defaultDoppelgangerDetection},
+			AffectsContainers:    []config.ContainerID{config.ContainerID_Validator},
+			EnvironmentVariables: []string{"DOPPELGANGER_DETECTION"},
+			CanBeBlank:           false,
+			OverwriteOnUpgrade:   false,
+		},
 	}
 }
 
@@ -578,6 +592,7 @@ func (cfg *ExternalTekuConfig) GetParameters() []*config.Parameter {
 		&cfg.Graffiti,
 		&cfg.ContainerTag,
 		&cfg.AdditionalVcFlags,
+		&cfg.DoppelgangerDetection,
 	}
 }
 

--- a/shared/services/config/geth-params.go
+++ b/shared/services/config/geth-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	gethTagProd          string = "ethereum/client-go:v1.13.4"
-	gethTagTest          string = "ethereum/client-go:v1.13.4"
+	gethTagProd          string = "ethereum/client-go:v1.13.7"
+	gethTagTest          string = "ethereum/client-go:v1.13.7"
 	gethEventLogInterval int    = 1000
 	gethStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/grafana-config.go
+++ b/shared/services/config/grafana-config.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Constants
-const grafanaTag string = "grafana/grafana:9.4.13"
+const grafanaTag string = "grafana/grafana:9.4.15"
 
 // Defaults
 const defaultGrafanaPort uint16 = 3100

--- a/shared/services/config/lodestar-config.go
+++ b/shared/services/config/lodestar-config.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	lodestarTagTest         string = "chainsafe/lodestar:v1.11.3"
-	lodestarTagProd         string = "chainsafe/lodestar:v1.11.3"
+	lodestarTagTest         string = "chainsafe/lodestar:v1.12.1"
+	lodestarTagProd         string = "chainsafe/lodestar:v1.12.1"
 	defaultLodestarMaxPeers uint16 = 50
 )
 

--- a/shared/services/config/nethermind-params.go
+++ b/shared/services/config/nethermind-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	nethermindTagProd          string = "nethermind/nethermind:1.21.0"
-	nethermindTagTest          string = "nethermind/nethermind:1.21.0"
+	nethermindTagProd          string = "nethermind/nethermind:1.24.0"
+	nethermindTagTest          string = "nethermind/nethermind:1.24.0"
 	nethermindEventLogInterval int    = 1000
 	nethermindStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/nimbus-config.go
+++ b/shared/services/config/nimbus-config.go
@@ -27,12 +27,12 @@ import (
 
 const (
 	// Testnet
-	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v23.9.1"
-	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v23.9.1"
+	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v23.11.0"
+	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v23.11.0"
 
 	// Mainnet
-	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v23.9.1"
-	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v23.9.1"
+	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v23.11.0"
+	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v23.11.0"
 
 	defaultNimbusMaxPeersArm uint16 = 100
 	defaultNimbusMaxPeersAmd uint16 = 160

--- a/shared/services/config/prometheus-config.go
+++ b/shared/services/config/prometheus-config.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Constants
-const prometheusTag string = "prom/prometheus:v2.45.0"
+const prometheusTag string = "prom/prometheus:v2.47.1"
 
 // Defaults
 const defaultPrometheusPort uint16 = 9091

--- a/shared/services/config/prysm-config.go
+++ b/shared/services/config/prysm-config.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.0.7"
-	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.0.7"
+	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.1.1"
+	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.1.1"
 
-	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.0.7"
-	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.0.7"
+	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.1.1"
+	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.1.1"
 
 	defaultPrysmRpcPort     uint16 = 5053
 	defaultPrysmOpenRpcPort bool   = false

--- a/shared/services/config/stader-config.go
+++ b/shared/services/config/stader-config.go
@@ -711,10 +711,8 @@ func (cfg *StaderConfig) IsDoppelgangerEnabled() (bool, error) {
 	case config.Mode_Local:
 		client := cfg.ConsensusClient.Value.(config.ConsensusClient)
 		switch client {
-		case config.ConsensusClient_Lighthouse, config.ConsensusClient_Lodestar, config.ConsensusClient_Nimbus, config.ConsensusClient_Prysm:
+		case config.ConsensusClient_Lighthouse, config.ConsensusClient_Lodestar, config.ConsensusClient_Nimbus, config.ConsensusClient_Prysm, config.ConsensusClient_Teku:
 			return cfg.ConsensusCommon.DoppelgangerDetection.Value.(bool), nil
-		case config.ConsensusClient_Teku:
-			return false, nil
 		default:
 			return false, fmt.Errorf("unknown consensus client [%v] selected", client)
 		}
@@ -729,7 +727,7 @@ func (cfg *StaderConfig) IsDoppelgangerEnabled() (bool, error) {
 		case config.ConsensusClient_Prysm:
 			return cfg.ExternalPrysm.DoppelgangerDetection.Value.(bool), nil
 		case config.ConsensusClient_Teku:
-			return false, nil
+			return cfg.ExternalTeku.DoppelgangerDetection.Value.(bool), nil
 		case config.ConsensusClient_Lodestar:
 			return cfg.ExternalLodestar.DoppelgangerDetection.Value.(bool), nil
 		default:

--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -61,9 +61,7 @@ func NewTekuConfig(cfg *StaderConfig) *TekuConfig {
 	return &TekuConfig{
 		Title: "Teku Settings",
 
-		UnsupportedCommonParams: []string{
-			DoppelgangerDetectionID,
-		},
+		UnsupportedCommonParams: []string{},
 
 		JvmHeapSize: config.Parameter{
 			ID:                   "jvmHeapSize",

--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	tekuTagTest         string = "consensys/teku:23.10.0"
-	tekuTagProd         string = "consensys/teku:23.10.0"
+	tekuTagTest         string = "consensys/teku:23.12.1"
+	tekuTagProd         string = "consensys/teku:23.12.1"
 	defaultTekuMaxPeers uint16 = 100
 )
 


### PR DESCRIPTION
1. Enabling doppleganger protection for teku in both local and externally managed mode
2. Updating client + monitoring versions