### PR TITLE
move bloxroute max profit relay to regulated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf // indirect
 	github.com/sethvargo/go-password v0.2.0
 	github.com/shirou/gopsutil/v3 v3.23.1
-	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231220054540-83f130b78833
-	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231220054540-83f130b78833
+	github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231226083422-f3da49b84cc1
+	github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231226083422-f3da49b84cc1
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli v1.22.10
 	github.com/wealdtech/go-eth2-types/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -1231,10 +1231,10 @@ github.com/spf13/viper v1.0.0/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7Sr
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231220054540-83f130b78833 h1:fdNP6MpGikpxIMTEtdnWVfvNg8yYyXZpx2+pXQd84pg=
-github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231220054540-83f130b78833/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231220054540-83f130b78833 h1:TgwSpUj+rdPQzmHUuQesGm648hRRERzaptISCfoIOUQ=
-github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231220054540-83f130b78833/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231226083422-f3da49b84cc1 h1:g0iwUPYfGEvaUkulr5o+40dR9UQFXconbLWN5+/DdoA=
+github.com/stader-labs/ethcli-ui/configuration v0.0.0-20231226083422-f3da49b84cc1/go.mod h1:gZcnx3O0sm+mEO2INhKDHw+iUzJH5tPaX4cv5SN5tsQ=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231226083422-f3da49b84cc1 h1:nmJhcmTlR/SkEg4A8wnkTI4fOSj33786crIyBKHB6eg=
+github.com/stader-labs/ethcli-ui/wizard v0.0.0-20231226083422-f3da49b84cc1/go.mod h1:5ojn2lxD9wd5sF0KYaHBDcpUC3ACFgqr0XG1atCIeAs=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/shared/services/config/geth-params.go
+++ b/shared/services/config/geth-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	gethTagProd          string = "ethereum/client-go:v1.13.7"
-	gethTagTest          string = "ethereum/client-go:v1.13.7"
+	gethTagProd          string = "ethereum/client-go:v1.13.8"
+	gethTagTest          string = "ethereum/client-go:v1.13.8"
 	gethEventLogInterval int    = 1000
 	gethStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/mev-boost-config.go
+++ b/shared/services/config/mev-boost-config.go
@@ -435,7 +435,7 @@ func createDefaultRelays() []config.MevRelay {
 				config.Network_Prater:  "https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.max-profit.builder.goerli.blxrbdn.com?id=staderlabs",
 				config.Network_Devnet:  "https://0x821f2a65afb70e7f2e820a925a9b4c80a159620582c1766b1b09729fec178b11ea22abb3a51f07b288be815a1a2ff516@bloxroute.max-profit.builder.goerli.blxrbdn.com?id=staderlabs",
 			},
-			Regulated:     false,
+			Regulated:     true,
 			NoSandwiching: false,
 		},
 		// bloXroute Regulated


### PR DESCRIPTION
BloxRoute has made all of their relays [regulated](https://twitter.com/bloXrouteLabs/status/1736819783520092357)(censoring). Move them to the regulated section in stader node