### PR TITLE
bump versions for upcoming deneb upgrade on goerli

### DIFF
--- a/shared/services/config/besu-params.go
+++ b/shared/services/config/besu-params.go
@@ -25,8 +25,8 @@ import (
 
 // Constants
 const (
-	besuTagTest          string = "hyperledger/besu:23.10.3-hotfix"
-	besuTagProd          string = "hyperledger/besu:23.10.3-hotfix"
+	besuTagTest          string = "hyperledger/besu:24.1.0"
+	besuTagProd          string = "hyperledger/besu:24.1.0"
 	besuEventLogInterval int    = 1000
 	besuMaxPeers         uint16 = 25
 	besuStopSignal       string = "SIGTERM"

--- a/shared/services/config/geth-params.go
+++ b/shared/services/config/geth-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	gethTagProd          string = "ethereum/client-go:v1.13.8"
-	gethTagTest          string = "ethereum/client-go:v1.13.8"
+	gethTagProd          string = "ethereum/client-go:v1.13.9"
+	gethTagTest          string = "ethereum/client-go:v1.13.9"
 	gethEventLogInterval int    = 1000
 	gethStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/lighthouse-config.go
+++ b/shared/services/config/lighthouse-config.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	lighthouseTagPortableTest string = "sigp/lighthouse:v4.5.0"
+	lighthouseTagPortableTest string = "sigp/lighthouse:v4.6.0-rc.0"
 	lighthouseTagPortableProd string = "sigp/lighthouse:v4.5.0"
-	lighthouseTagModernTest   string = "sigp/lighthouse:v4.5.0-modern"
+	lighthouseTagModernTest   string = "sigp/lighthouse:v4.6.0-rc.0"
 	lighthouseTagModernProd   string = "sigp/lighthouse:v4.5.0-modern"
 	defaultLhMaxPeers         uint16 = 80
 )

--- a/shared/services/config/lodestar-config.go
+++ b/shared/services/config/lodestar-config.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	lodestarTagTest         string = "chainsafe/lodestar:v1.12.1"
-	lodestarTagProd         string = "chainsafe/lodestar:v1.12.1"
+	lodestarTagTest         string = "chainsafe/lodestar:v1.14.1-rc.1"
+	lodestarTagProd         string = "chainsafe/lodestar:v1.13.0"
 	defaultLodestarMaxPeers uint16 = 50
 )
 

--- a/shared/services/config/nethermind-params.go
+++ b/shared/services/config/nethermind-params.go
@@ -28,8 +28,8 @@ import (
 
 // Constants
 const (
-	nethermindTagProd          string = "nethermind/nethermind:1.24.0"
-	nethermindTagTest          string = "nethermind/nethermind:1.24.0"
+	nethermindTagProd          string = "nethermind/nethermind:1.25.0"
+	nethermindTagTest          string = "nethermind/nethermind:1.25.0"
 	nethermindEventLogInterval int    = 1000
 	nethermindStopSignal       string = "SIGTERM"
 )

--- a/shared/services/config/nimbus-config.go
+++ b/shared/services/config/nimbus-config.go
@@ -27,12 +27,12 @@ import (
 
 const (
 	// Testnet
-	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v23.11.0"
-	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v23.11.0"
+	nimbusBnTagTest string = "statusim/nimbus-eth2:multiarch-v24.1.1"
+	nimbusVcTagTest string = "statusim/nimbus-validator-client:multiarch-v24.1.1"
 
 	// Mainnet
-	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v23.11.0"
-	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v23.11.0"
+	nimbusBnTagProd string = "statusim/nimbus-eth2:multiarch-v24.1.1"
+	nimbusVcTagProd string = "statusim/nimbus-validator-client:multiarch-v24.1.1"
 
 	defaultNimbusMaxPeersArm uint16 = 100
 	defaultNimbusMaxPeersAmd uint16 = 160

--- a/shared/services/config/prysm-config.go
+++ b/shared/services/config/prysm-config.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.1.1"
-	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.1.1"
+	prysmBnTagTest string = "nethermindeth/prysm-beacon-chain:v4.2.0"
+	prysmVcTagTest string = "nethermindeth/prysm-validator:v4.2.0"
 
-	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.1.1"
-	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.1.1"
+	prysmBnTagProd string = "nethermindeth/prysm-beacon-chain:v4.2.0"
+	prysmVcTagProd string = "nethermindeth/prysm-validator:v4.2.0"
 
 	defaultPrysmRpcPort     uint16 = 5053
 	defaultPrysmOpenRpcPort bool   = false

--- a/shared/services/config/teku-config.go
+++ b/shared/services/config/teku-config.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	tekuTagTest         string = "consensys/teku:23.12.1"
-	tekuTagProd         string = "consensys/teku:23.12.1"
+	tekuTagTest         string = "consensys/teku:24.1.0"
+	tekuTagProd         string = "consensys/teku:24.1.0"
 	defaultTekuMaxPeers uint16 = 100
 )
 

--- a/shared/version.go
+++ b/shared/version.go
@@ -21,7 +21,7 @@ package shared
 
 const BinaryBucket string = "/stader-node-build/permissionless"
 const DockerAccount string = "staderlabs"
-const StaderVersion string = "1.4.5"
+const StaderVersion string = "1.4.6"
 
 const Logo string = ` 
   _____ _            _             _           _       𝅺 	


### PR DESCRIPTION
Deneb is being released on Goerli on 17th Jan. This PR prepares stader-node for such upgrades https://blog.ethereum.org/2024/01/10/goerli-dencun-announcement 