### PR TITLE
Nipun/ssv flag different validator dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -417,8 +417,9 @@ fi
 
 
 # Create ~/.stader dir & files
+# //ssv-flag
 progress 6 "Creating Stader user data directory..."
-{ mkdir -p "$DATA_PATH/validators" || fail "Could not create the Stader user data directory."; } >&2
+{ mkdir -p "$DATA_PATH/$HOST_VALIDATORS_DIR_NAME" || fail "Could not create the Stader user data directory."; } >&2
 { mkdir -p "$STADER_PATH/runtime" || fail "Could not create the Stader runtime directory."; } >&2
 { mkdir -p "$DATA_PATH/secrets" || fail "Could not create the Stader secrets directory."; } >&2
 { mkdir -p "$DATA_PATH/sp-rewards-merkle-proofs" || fail "Could not create the Stader socializing pool rewards merkle proofs directory."; } >&2

--- a/install/templates/api.tmpl
+++ b/install/templates/api.tmpl
@@ -35,6 +35,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${STADER_FOLDER}:/.stader
       - ${STADER_DATA_FOLDER}:/.stader/data
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/.stader/data/validators
     networks:
       - net
     entrypoint: /bin/sleep

--- a/install/templates/eth1.tmpl
+++ b/install/templates/eth1.tmpl
@@ -37,6 +37,7 @@ services:
       - eth1clientdata:/ethclient
       - ${STADER_FOLDER}/scripts:/setup:ro
       - ${STADER_DATA_FOLDER}/secrets:/secrets
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/.stader/data/validators
     networks:
       - net
     environment:

--- a/install/templates/eth2.tmpl
+++ b/install/templates/eth2.tmpl
@@ -33,7 +33,7 @@ services:
     stop_grace_period: 3m
     ports: [ "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/tcp", "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/udp"${BN_OPEN_PORTS} ]
     volumes:
-      - ${STADER_DATA_FOLDER}/validators:/validators
+      - ${STADER_DATA_FOLDER}/${VALIDATORS_DIR_NAME}:/validators
       - ${STADER_DATA_FOLDER}/secrets:/secrets:ro
       - eth2clientdata:/ethclient
       - ${STADER_FOLDER}/scripts:/setup:ro

--- a/install/templates/eth2.tmpl
+++ b/install/templates/eth2.tmpl
@@ -33,7 +33,7 @@ services:
     stop_grace_period: 3m
     ports: [ "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/tcp", "${BN_P2P_PORT:-9001}:${BN_P2P_PORT:-9001}/udp"${BN_OPEN_PORTS} ]
     volumes:
-      - ${STADER_DATA_FOLDER}/${VALIDATORS_DIR_NAME}:/validators
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/validators
       - ${STADER_DATA_FOLDER}/secrets:/secrets:ro
       - eth2clientdata:/ethclient
       - ${STADER_FOLDER}/scripts:/setup:ro

--- a/install/templates/guardian.tmpl
+++ b/install/templates/guardian.tmpl
@@ -33,6 +33,7 @@ services:
     volumes:
       - ${STADER_FOLDER}:/.stader
       - ${STADER_DATA_FOLDER}:/.stader/data
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/.stader/data/validators
     networks:
       - net
     command: "-m 0.0.0.0 -r ${NODE_METRICS_PORT:-9104} guardian"

--- a/install/templates/mev-boost.tmpl
+++ b/install/templates/mev-boost.tmpl
@@ -32,6 +32,7 @@ services:
     ports: [${MEV_BOOST_OPEN_API_PORT}]
     volumes:
       - ${STADER_FOLDER}/scripts:/setup:ro
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/.stader/data/validators
     networks:
       - net
     environment:

--- a/install/templates/node.tmpl
+++ b/install/templates/node.tmpl
@@ -33,6 +33,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${STADER_FOLDER}:/.stader
       - ${STADER_DATA_FOLDER}:/.stader/data
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/.stader/data/validators
     networks:
       - net
     command: "node"

--- a/install/templates/validator.tmpl
+++ b/install/templates/validator.tmpl
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 3m
     volumes:
-      - ${STADER_DATA_FOLDER}/validators:/validators
+      - ${STADER_DATA_FOLDER}/${VALIDATORS_DIR_NAME}:/validators
       - ${STADER_FOLDER}/scripts:/setup:ro
       - ${STADER_FOLDER}/addons:/addons
     networks:

--- a/install/templates/validator.tmpl
+++ b/install/templates/validator.tmpl
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 3m
     volumes:
-      - ${STADER_DATA_FOLDER}/${VALIDATORS_DIR_NAME}:/validators
+      - ${STADER_DATA_FOLDER}/${HOST_VALIDATORS_DIR_NAME}:/validators
       - ${STADER_FOLDER}/scripts:/setup:ro
       - ${STADER_FOLDER}/addons:/addons
     networks:

--- a/shared/services/config/stader-config.go
+++ b/shared/services/config/stader-config.go
@@ -851,9 +851,9 @@ func (cfg *StaderConfig) GenerateEnvironmentVariables() map[string]string {
 	envVars["TX_FEE_CAP"] = fmt.Sprintf("%d", int64(txFeeCap))
 	envVars["TX_FEE_CAP_IN_GWEI"] = fmt.Sprintf("%d", int64(txFeeCapInGwei))
 	envVars["SSV_MODE"] = fmt.Sprintf("%v", cfg.IsSSVMode)
-	envVars["VALIDATORS_DIR_NAME"] = "validators" // default validators dir name
+	envVars["HOST_VALIDATORS_DIR_NAME"] = "validators" // default validators dir name
 	if cfg.IsSSVMode {
-		envVars["VALIDATORS_DIR_NAME"] = "presign" // sets the directory name for validator info in case of ssv mode is set to true.
+		envVars["HOST_VALIDATORS_DIR_NAME"] = "presign" // sets the directory name for validator info in case of ssv mode is set to true.
 	}
 	config.AddParametersToEnvVars(cfg.StaderNode.GetParameters(), envVars)
 	config.AddParametersToEnvVars(cfg.GetParameters(), envVars)

--- a/shared/services/config/stader-config.go
+++ b/shared/services/config/stader-config.go
@@ -851,6 +851,10 @@ func (cfg *StaderConfig) GenerateEnvironmentVariables() map[string]string {
 	envVars["TX_FEE_CAP"] = fmt.Sprintf("%d", int64(txFeeCap))
 	envVars["TX_FEE_CAP_IN_GWEI"] = fmt.Sprintf("%d", int64(txFeeCapInGwei))
 	envVars["SSV_MODE"] = fmt.Sprintf("%v", cfg.IsSSVMode)
+	envVars["VALIDATORS_DIR_NAME"] = "validators" // default validators dir name
+	if cfg.IsSSVMode {
+		envVars["VALIDATORS_DIR_NAME"] = "presign" // sets the directory name for validator info in case of ssv mode is set to true.
+	}
 	config.AddParametersToEnvVars(cfg.StaderNode.GetParameters(), envVars)
 	config.AddParametersToEnvVars(cfg.GetParameters(), envVars)
 

--- a/shared/services/config/stadernode-config.go
+++ b/shared/services/config/stadernode-config.go
@@ -446,11 +446,15 @@ func (cfg *StaderNodeConfig) GetSpRewardCyclePath(cycle int64, daemon bool) stri
 }
 
 func (cfg *StaderNodeConfig) GetFeeRecipientFilePath() string {
+	validatorDirName := "validators"
+	if cfg.parent.IsSSVMode {
+		validatorDirName = "presign"
+	}
 	if !cfg.parent.IsNativeMode {
-		return filepath.Join(DaemonDataPath, "validators", FeeRecipientFilename)
+		return filepath.Join(DaemonDataPath, validatorDirName, FeeRecipientFilename)
 	}
 
-	return filepath.Join(cfg.DataPath.Value.(string), "validators", NativeFeeRecipientFilename)
+	return filepath.Join(cfg.DataPath.Value.(string), validatorDirName, NativeFeeRecipientFilename)
 }
 
 func (cfg *StaderNodeConfig) GetClaimData(cycles []*big.Int) ([]*big.Int, []*big.Int, [][][32]byte, error) {

--- a/shared/services/config/stadernode-config.go
+++ b/shared/services/config/stadernode-config.go
@@ -446,15 +446,11 @@ func (cfg *StaderNodeConfig) GetSpRewardCyclePath(cycle int64, daemon bool) stri
 }
 
 func (cfg *StaderNodeConfig) GetFeeRecipientFilePath() string {
-	validatorDirName := "validators"
-	if cfg.parent.IsSSVMode {
-		validatorDirName = "presign"
-	}
 	if !cfg.parent.IsNativeMode {
-		return filepath.Join(DaemonDataPath, validatorDirName, FeeRecipientFilename)
+		return filepath.Join(DaemonDataPath, "validators", FeeRecipientFilename)
 	}
 
-	return filepath.Join(cfg.DataPath.Value.(string), validatorDirName, NativeFeeRecipientFilename)
+	return filepath.Join(cfg.DataPath.Value.(string), "validators", NativeFeeRecipientFilename)
 }
 
 func (cfg *StaderNodeConfig) GetClaimData(cycles []*big.Int) ([]*big.Int, []*big.Int, [][][32]byte, error) {


### PR DESCRIPTION
Aim of the PR :

1. we are suppose to use "presign" dir in place of "validators"
2. wallet users validators dir, it should use the presign directory.

broadly, in this PR, I have changes the host directory to be "presign" directory and mounted for the "validators" path.
the rest of logic remain as it it.

changes : 
1. update the flow that created these stader node related directory : install.sh
2. update the templates to add mounting for validators path